### PR TITLE
Fix mixin inheritance

### DIFF
--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -21,8 +21,9 @@ The view requires :code:`HtmxViewMixin`
 .. code-block:: python
 
     from hx_requests.views import HtmxViewMixin
+    from django.views.generic.base import View
 
-    class MyView(HtmxViewMixin):
+    class MyView(HtmxViewMixin, View):
         pass
 
 The HTML
@@ -108,8 +109,9 @@ The view requires :code:`HtmxViewMixin`
 .. code-block:: python
 
     from hx_requests.views import HtmxViewMixin
+    from django.views.generic.base import View
 
-    class MyView(HtmxViewMixin):
+    class MyView(HtmxViewMixin, View):
         pass
 
 The HTML

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -6,13 +6,12 @@ from django.apps import apps
 from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.generic.base import View
 
 from hx_requests.utils import deserialize_kwargs, is_htmx_request
 
 
 @method_decorator(ensure_csrf_cookie, name="dispatch")
-class HtmxViewMixin(View):
+class HtmxViewMixin:
     """
     Mixin to be added to views that are using HXRequests.
     Hijacks the get and post to route them to the proper


### PR DESCRIPTION
Remove View as parent class of HtmxViewMixin to avoid inheriting View twice in subclasses.
Issue #32 