### PR TITLE
fix: exception when missing csrf

### DIFF
--- a/hx_requests/templatetags/hx_tags.py
+++ b/hx_requests/templatetags/hx_tags.py
@@ -9,31 +9,54 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def render_hx(
-    context: Dict, hx_request_name: str, method: str = "get", object=None, use_full_path=False, **kwargs
+    context: Dict,
+    hx_request_name: str,
+    method: str = "get",
+    object=None,
+    use_full_path=False,
+    **kwargs,
 ) -> str:
     """
     Renders out the hx-post or hx-get with the correct url along with all kwargs
     turned into GET params.
     """
-    url = get_url(context, hx_request_name, object,use_full_path ,**kwargs)
-
-    token = get_csrf_token(context)
-    return f""" hx-{method}={url}
-                hx-headers={{"X-CSRFTOKEN":"{token}"}}
-            """
+    url = get_url(context, hx_request_name, object, use_full_path, **kwargs)
+    return f"hx-{method}={url}"
 
 
 @register.simple_tag(takes_context=True)
-def hx_get(context: Dict, hx_request_name: str, object=None, use_full_path=False, **kwargs) -> str:
+def hx_get(
+    context: Dict, hx_request_name: str, object=None, use_full_path=False, **kwargs
+) -> str:
     """
     Same as render_hx EXCEPT that it is specifically for 'get' requests.
     """
-    return render_hx(context, hx_request_name, method="get", object=object, use_full_path=use_full_path, **kwargs)
+    return render_hx(
+        context,
+        hx_request_name,
+        method="get",
+        object=object,
+        use_full_path=use_full_path,
+        **kwargs,
+    )
 
 
 @register.simple_tag(takes_context=True)
-def hx_post(context: Dict, hx_request_name: str, object=None,use_full_path=False ,**kwargs) -> str:
+def hx_post(
+    context: Dict, hx_request_name: str, object=None, use_full_path=False, **kwargs
+) -> str:
     """
     Same as render_hx EXCEPT that it is specifically for 'post' requests.
     """
-    return render_hx(context, hx_request_name, method="post", object=object, use_full_path=use_full_path, **kwargs)
+    hx_attrs = render_hx(
+        context,
+        hx_request_name,
+        method="post",
+        object=object,
+        use_full_path=use_full_path,
+        **kwargs,
+    )
+    token = get_csrf_token(context)
+    if token:
+        hx_attrs += f' hx-headers={{"X-CSRFTOKEN":"{token}"}}'
+    return hx_attrs

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.db import models
 from urllib.parse import urlencode, quote_plus
 
+
 def is_htmx_request(request):
     return "HX-Request" in request.headers
 
@@ -24,28 +25,35 @@ def deserialize_kwargs(**kwargs):
             kwargs[k] = instance
     return kwargs
 
+
 def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
     request = context["request"]
     url = request.path
 
-    params = {'hx_request_name': hx_request_name}
-    
+    params = {"hx_request_name": hx_request_name}
+
     if use_full_path:
-        params.update({k: v for k, v in request.GET.items() if k not in ['hx_request_name','object']})
+        params.update(
+            {
+                k: v
+                for k, v in request.GET.items()
+                if k not in ["hx_request_name", "object"]
+            }
+        )
 
     if obj:
-        params['object'] = f"{obj._meta.app_label}_{obj._meta.model.__name__}_{obj.pk}"
+        params["object"] = f"{obj._meta.app_label}_{obj._meta.model.__name__}_{obj.pk}"
 
-        
     url += f"?{urlencode(params)}"
 
     serialized_kwargs = serialize_kwargs(**kwargs)
-    url += ''.join(f"&{k}={quote_plus(str(v))}" for k, v in serialized_kwargs.items())
+    url += "".join(f"&{k}={quote_plus(str(v))}" for k, v in serialized_kwargs.items())
 
     return url
 
+
 def get_csrf_token(context):
     cookie = context["request"].headers.get("cookie")
-    if cookie:
+    if cookie and "csrftoken" in cookie:
         token = cookie.split("csrftoken=")[1].split(";")[0]
         return token


### PR DESCRIPTION
Exclude CSRF for GET and ignore missing CSRF token and let Django handle it naturally.
Resolves #51 