### PR TITLE
feat: Change message tag to tags and add __str__ method to Message

### DIFF
--- a/docs/guide/messages.rst
+++ b/docs/guide/messages.rst
@@ -21,7 +21,7 @@ To use :code:`hx-messages` a few things need to be set...
     <div id="hx_messages" hx-swap-oob='true'>
         <ul class="messages">
             {% for message in messages %}
-                <li class="alert {{ message.tag }}">{{ message.body|safe }}</li>
+                <li class="alert {{ message.tags }}">{{ message|safe }}</li>
             {% endfor %}
         </ul>
     </div>

--- a/hx_requests/hx_messages.py
+++ b/hx_requests/hx_messages.py
@@ -15,7 +15,10 @@ class HXMessageTags:
 @dataclass
 class Message:
     body: str
-    tag: str
+    tags: str
+
+    def __str__(self):
+        return self.body
 
 
 class HXMessages:

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -245,7 +245,7 @@ class BaseHXRequest:
                     (
                         key
                         for key, value in self.messages.tags.items()
-                        if value == message.tag
+                        if value == message.tags
                     )
                 )
                 messages.add_message(


### PR DESCRIPTION
This is a BREAKING CHANGE. In the message template tag needs to be changed to tags. Also, the message object now has a __str__ method so instead of doing message.body in the template, you can just do message.