### PR TITLE
fix! Rename HxRequest classes to be more semantic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and a 1.0.0 release
 ### Fix
 
 * Fix bug in HtmxViewMixin._get_hx_request_classes ([`e797a2e`](https://github.com/yaakovLowenstein/hx-requests/commit/e797a2ea5c47a144fdc547b3971ef86d64ad276a))
-* Raise an exception if duplicate HXRequest names are found ([`7c9fa47`](https://github.com/yaakovLowenstein/hx-requests/commit/7c9fa47a2cdf51fada1e61adabe5f44de5c5caaa))
+* Raise an exception if duplicate HxRequest names are found ([`7c9fa47`](https://github.com/yaakovLowenstein/hx-requests/commit/7c9fa47a2cdf51fada1e61adabe5f44de5c5caaa))
 
 ### Documentation
 
@@ -41,7 +41,7 @@ and a 1.0.0 release
 * The hx_messages module has been removed.
     Messages are now set using Django's messaging framework.
     The HXMessages class has been removed and the messages attribute
-    has been removed from the BaseHXRequest class. Messages are
+    has been removed from the BaseHxRequest class. Messages are
     now set using Django's messages module.
 
     `self.messages.success()` has been replaced with
@@ -49,11 +49,11 @@ and a 1.0.0 release
     `self.messages.error()`, `self.messages.warning()`,
     `self.messages.info()` and `self.messages.debug()`. ([`35caf9a`](https://github.com/yaakovLowenstein/hx-requests/commit/35caf9a58ae4a5eee78c7de8200bff177bc13e29))
 * This changes the method name from handle_delete
-    to delete in DeleteHXRequest. If you have overridden handle_delete
-    in your DeleteHXRequest, you will need to change it to delete. ([`4022933`](https://github.com/yaakovLowenstein/hx-requests/commit/4022933d26db5d649eba12efa1346fd296ea29f0))
+    to delete in DeleteHxRequest. If you have overridden handle_delete
+    in your DeleteHxRequest, you will need to change it to delete. ([`4022933`](https://github.com/yaakovLowenstein/hx-requests/commit/4022933d26db5d649eba12efa1346fd296ea29f0))
 * This will break any custom modals that use
     the modalFormValid event. They will need to be updated to use
-    closeHxModal instead. (and if using Alpin.js modal-form-valid
+    closeModalHxRequest instead. (and if using Alpin.js modal-form-valid
     needs to be changed to close-hx-modal) ([`786c6a3`](https://github.com/yaakovLowenstein/hx-requests/commit/786c6a334d5227bc7d158f58bdbe609422080e37))
 * The render_hx template tag has been removed.
     It has been replaced by the hx_get and hx_post template tags.
@@ -74,7 +74,7 @@ and a 1.0.0 release
     form_valid and form_invalid methods if you override them as opposed
     to previously where the messages were set in the POST methods so they
     were set even when overriding form_valid and form_invalid. The
-    DeleteHXRequest class has also been updated to reflect this change.
+    DeleteHxRequest class has also been updated to reflect this change.
     where messages are now set in the delete method and not the POST method. ([`bcf9df2`](https://github.com/yaakovLowenstein/hx-requests/commit/bcf9df2758830d055d4b796558ac62ede4b71057))
 
 ## What's Changed
@@ -121,7 +121,7 @@ and a 1.0.0 release
 
 ### Fix
 
-* Fix get_triggers method in HXFormModal class when form is invalid ([`df23c7a`](https://github.com/yaakovLowenstein/hx-requests/commit/df23c7a528e834277c86da29d396c5703ba3cdce))
+* Fix get_triggers method in FormModalHxRequest class when form is invalid ([`df23c7a`](https://github.com/yaakovLowenstein/hx-requests/commit/df23c7a528e834277c86da29d396c5703ba3cdce))
 
 ## v0.28.0 (2024-05-02)
 
@@ -150,13 +150,13 @@ and a 1.0.0 release
 
 ### Fix
 
-* Use body_template instead of GET_template for HXModal ([`f28723e`](https://github.com/yaakovLowenstein/hx-requests/commit/f28723ea3cb1b341e1e7e48544d99af9c2b4377f))
+* Use body_template instead of GET_template for ModalHxRequest ([`f28723e`](https://github.com/yaakovLowenstein/hx-requests/commit/f28723ea3cb1b341e1e7e48544d99af9c2b4377f))
 * Change HX_REQUESTS_MODAL_BODY_SELECTOR to HX_REQUESTS_MODAL_BODY_ID ([`b79abde`](https://github.com/yaakovLowenstein/hx-requests/commit/b79abde9e0067579872833605a19cec4d09eb105))
 
 ### Breaking
 
 * The default modal templates have been removed. You will need to create your own modal templates if you want to use the modal functionality. See the docs for more information. ([`c27e317`](https://github.com/yaakovLowenstein/hx-requests/commit/c27e3174fb7063829175c46942668017d262ecdf))
-* The GET_template is no longer used for the HXModal. Instead the body_template is used. What was previously set as GET_template should now be set as body_template. ([`f28723e`](https://github.com/yaakovLowenstein/hx-requests/commit/f28723ea3cb1b341e1e7e48544d99af9c2b4377f))
+* The GET_template is no longer used for the ModalHxRequest. Instead the body_template is used. What was previously set as GET_template should now be set as body_template. ([`f28723e`](https://github.com/yaakovLowenstein/hx-requests/commit/f28723ea3cb1b341e1e7e48544d99af9c2b4377f))
 * HX_REQUESTS_MODAL_BODY_SELECTOR is now HX_REQUESTS_MODAL_BODY_ID and the default is now #hx_modal_body. (set hx_modal_body as the html id on the modal body) ([`b79abde`](https://github.com/yaakovLowenstein/hx-requests/commit/b79abde9e0067579872833605a19cec4d09eb105))
 
 ### Documentation
@@ -179,7 +179,7 @@ and a 1.0.0 release
 
 ### Feature
 
-* Add kwargs_as_context option to BaseHXRequest ([`8eecaa6`](https://github.com/yaakovLowenstein/hx-requests/commit/8eecaa61bcbcfeab6a7d2774fd794711ccbcd285))
+* Add kwargs_as_context option to BaseHxRequest ([`8eecaa6`](https://github.com/yaakovLowenstein/hx-requests/commit/8eecaa61bcbcfeab6a7d2774fd794711ccbcd285))
 
 ### Breaking
 
@@ -443,9 +443,9 @@ and a 1.0.0 release
 * Trying to get readthedocs to recognize docstrings ([`680fc98`](https://github.com/yaakovLowenstein/hx-requests/commit/680fc9887d35bb1c2d02274379d188a198c01559))
 * Add requirements and yml for readthedocs ([`f50a7b3`](https://github.com/yaakovLowenstein/hx-requests/commit/f50a7b3004f38c0b059328850c2669768bc92d3b))
 * Fix typo in quickstart ([`8d03c06`](https://github.com/yaakovLowenstein/hx-requests/commit/8d03c06c44f6ecbe54f462be7623961b2c02f32c))
-* Add reference documentation for DeleteHXRequest ([`58fe070`](https://github.com/yaakovLowenstein/hx-requests/commit/58fe070c30b2ee2c7d764ce64df3a8cdb72cf787))
-* Add in docstrings for FormHXRequest ([`558bac8`](https://github.com/yaakovLowenstein/hx-requests/commit/558bac8230f2ecf8d34b54544339e2664aa94352))
-* Add reference docs for FormHXRequest ([`263c533`](https://github.com/yaakovLowenstein/hx-requests/commit/263c533c1d2b166957a77c52c91c1cbf30f3a0c7))
+* Add reference documentation for DeleteHxRequest ([`58fe070`](https://github.com/yaakovLowenstein/hx-requests/commit/58fe070c30b2ee2c7d764ce64df3a8cdb72cf787))
+* Add in docstrings for FormHxRequest ([`558bac8`](https://github.com/yaakovLowenstein/hx-requests/commit/558bac8230f2ecf8d34b54544339e2664aa94352))
+* Add reference docs for FormHxRequest ([`263c533`](https://github.com/yaakovLowenstein/hx-requests/commit/263c533c1d2b166957a77c52c91c1cbf30f3a0c7))
 
 ## v0.10.2 (2023-05-02)
 ### Fix

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ views and urls with extra code. It simplifies making django forms post asyncrono
 with htmx, and many other awesome features.
 
 The idea of hx-requests is that `HXRequests` absorb all htmx requests.
-Define an `HXRequest` and
+Define an `HxRequest` and
 observe the magic of `hx-requests`.
 
 - No need to define extra urls to handle these requests

--- a/docs/guide/blocks.rst
+++ b/docs/guide/blocks.rst
@@ -3,7 +3,7 @@ Rendering Blocks
 
 Thanks to `django-render-block <https://github.com/clokep/django-render-block>`_ there is a way to reduce using :code:`includes`. Instead of needing to
 split out templates into includes to use them for partials, you can specify a block from the template to use and that block will be rendered by the
-:code:`HXRequest`.
+:code:`HxRequest`.
 
 Example
 -------
@@ -52,13 +52,13 @@ Using the example from :ref:`forms <HTML>`, instead of using an :code:`include`,
         </button>
     </form>
 
-And the :code:`HXRequest`:
+And the :code:`HxRequest`:
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class UserInfoHXRequest(FormHXRequest):
+    class UserInfoHXRequest(FormHxRequest):
         ...
         # Instead of this (which was the include)
         POST_template = 'user_info.html'
@@ -73,11 +73,11 @@ Another Example
 ---------------
 
 
-*HXRequest*
+*HxRequest*
 
 .. code-block:: python
 
-    class UpdateUser(FormHXRequest):
+    class UpdateUser(FormHxRequest):
         name = "update_user"
         form_class = UpdateUserForm # Form with a username field
         GET_template = "user_form.html"
@@ -121,7 +121,7 @@ Another Example
 
 Notes:
 
-    - This is a :code:`FormHXRequest` that replaces a row of the table with a form to edit the contents of the row (i.e. username)
-    - On post the :code:`HXRequest` will return just the table because the :code:`POST_block` was set to table and in :code:`big_template.html` that
+    - This is a :code:`FormHxRequest` that replaces a row of the table with a form to edit the contents of the row (i.e. username)
+    - On post the :code:`HxRequest` will return just the table because the :code:`POST_block` was set to table and in :code:`big_template.html` that
       block contains the table. This is helpful because the only thing on the page that should be updated on post is the table.
     - If not for :code:`django-render-block` the table would have to be a separate include so that you could specifiy the table template as the :code:`POST_template`

--- a/docs/guide/delete.rst
+++ b/docs/guide/delete.rst
@@ -1,7 +1,7 @@
 Deleting
 ========
 
-:code:`hx-requests` has a build in **Delete** :code:`HXRequest` which makes it really easy to asyncronously delete something.
+:code:`hx-requests` has a build in **Delete** :code:`HxRequest` which makes it really easy to asyncronously delete something.
 
 .. code-block:: html
 
@@ -18,7 +18,7 @@ Notes:
 
 .. code-block:: python
 
-    class DeleteUser(DeleteHXRequest):
+    class DeleteUser(DeleteHxRequest):
         name = "delete_user"
         POST_template = "..." # html returned on post (used to update DOM)
 

--- a/docs/guide/faqs.rst
+++ b/docs/guide/faqs.rst
@@ -1,24 +1,24 @@
 FAQs
 ====
 
-**How do I make the page refresh when using an HXRequest?**
+**How do I make the page refresh when using an HxRequest?**
 
 Set :code:`refresh_page` to True.
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
         refresh_page = True
 
 
-**How do I redirect to a new page when using an HXRequest?**
+**How do I redirect to a new page when using an HxRequest?**
 
-Set redirect to the URL the :code:`HXRequest` should redirect to.
+Set redirect to the URL the :code:`HxRequest` should redirect to.
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
         redirect = "my-website/home"
 
@@ -29,7 +29,7 @@ Set :code:`refresh` or :code:`redirect` in form_invalid.
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
         refresh=True # or redirect = "my-website/home"
 
@@ -39,7 +39,7 @@ Set :code:`refresh` or :code:`redirect` in form_invalid.
 
 **What is return_empty for?**
 
-:code:`return_empty` returns an empty :code:`HttpResponse` from the :code:`HXRequest`. An example of where it may be used is a 'save for later'
+:code:`return_empty` returns an empty :code:`HttpResponse` from the :code:`HxRequest`. An example of where it may be used is a 'save for later'
 button in a shopping cart. The item needs to disappear from the cart, but there is nothing on the page that needs to be updated. Therfore you
 want to return an empty :code:`HTTPResponse`. Another example is a delete where nothing on the page needs to be updated.
 
@@ -51,7 +51,7 @@ when the form in invalid, you may want to just set a message with the errors.
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
 
         def form_invalid(self,**kwargs):
@@ -60,13 +60,13 @@ when the form in invalid, you may want to just set a message with the errors.
             return super().form_invalid(**kwargs)
 
 
-**How do I put the form errors into the error message when using a FormHXRequest?**
+**How do I put the form errors into the error message when using a FormHxRequest?**
 
 Setting :code:`add_form_errors_to_error_message` to True will put the form's errors into the error message.
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
         add_form_errors_to_error_message = True
 
@@ -76,7 +76,7 @@ If you want to put the :code:`hx_object` into the context with a different name,
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         ...
         hx_object_name = "my_object"
 

--- a/docs/guide/forms.rst
+++ b/docs/guide/forms.rst
@@ -3,7 +3,7 @@ Using Forms
 
 | Probably the most common thing to use :code:`HXRequests` with is forms. :code:`HXRequests` gives a simple way to post data and update the page asyncronously.
 |
-| Using a :code:`FormHXRequest` the form is fetched asyncronously using the :code:`GET_template`, the form is saved and then it returns the :code:`POST_template`
+| Using a :code:`FormHxRequest` the form is fetched asyncronously using the :code:`GET_template`, the form is saved and then it returns the :code:`POST_template`
 
 
 Basic Form
@@ -52,23 +52,23 @@ HTML
     {{ user.last_name }}
 
 Notes:
-    - 'user_info_form' in the template tags is the name of the :code:`HXRequest` that these requests will be routed to (see below)
+    - 'user_info_form' in the template tags is the name of the :code:`HxRequest` that these requests will be routed to (see below)
     - :code:`object` is equivalent to an instance in a Django form. In the :code:`get` it's used to set the initial of the fields. In the :code:`post` it's the object that is getting updated.
-    - An :code:`include` is used so that it can be reused below as the :code:`POST_template` in the :code:`HXRequest`.
+    - An :code:`include` is used so that it can be reused below as the :code:`POST_template` in the :code:`HxRequest`.
     - The user in :code:`user_info.html` comes from the context of the view.
 
 .. tip::
 
     :code:`includes` are very helpful when using htmx, because it gives an easy way to load part of the html.
 
-HXRequest
+HxRequest
 ~~~~~~~~~
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class UserInfoHXRequest(FormHXRequest):
+    class UserInfoHXRequest(FormHxRequest):
         name = "user_info_form"
         form_class = UserInfoForm
         GET_template = 'form.html' # Renders the form
@@ -92,7 +92,7 @@ Notes:
     - :code:`form_invalid` by default returns the :code:`GET_template`. The purpose of this is to show the error messages. Because :code:`is_valid` was called (:code:`is_valid` is called in the :code:`post` method), the form now contains the errors, which gives you asyncronous validation of the form.
     - The :code:`GET_template` (*form.html*) has access to the form as 'form' in the context
     - :code:`hx_object_name` is the name given to the object when it's passed into the context. Above in :code:`user_info.html` (the :code:`POST_template`), on :code:`POST` the user in that context is the object that was passed in to the :code:`hx_post` template tag (although now it was updated by the form). If :code:`hx_object_name` was not set, instead of referencing the object as 'user' in :code:`user_info.html`, it would be referenced as :code:`hx_object` (i.e. :code:`hx_object.username`)
-    - The object is saved as an attribute on the :code:`HXRequest` as :code:`hx_object`, so it can be referenced anywhere in the class as :code:`self.hx_object`
+    - The object is saved as an attribute on the :code:`HxRequest` as :code:`hx_object`, so it can be referenced anywhere in the class as :code:`self.hx_object`
 
 Setting Form Kwargs
 -------------------
@@ -102,9 +102,9 @@ Setting Form Kwargs
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         # Set attributes
 
         def get_form_kwargs(self,**kwargs):
@@ -127,7 +127,7 @@ As long as the key in the kwargs matches the name of a field in the form, it wil
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
     class MyForm(forms.ModelForm):
 
@@ -135,7 +135,7 @@ As long as the key in the kwargs matches the name of a field in the form, it wil
             model = MyModel
             fields = ['field1', 'field2']
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         name='my_hx_request'
         set_initial_from_kwargs = True
 
@@ -154,11 +154,11 @@ Setting :ref:`Messages`
 
     See :ref:`Messages` for more details and for config settings.
 
-In a :code:`FormHXRequest` success and error messages can be set by overriding :code:`get_success_message` and :code:`get_error_message`
+In a :code:`FormHxRequest` success and error messages can be set by overriding :code:`get_success_message` and :code:`get_error_message`
 
 .. code-block:: python
 
-    class MyHXRequest(FormHXRequest):
+    class MyHXRequest(FormHxRequest):
         # Set attributes
 
         def get_success_message(self, **kwargs) -> str:
@@ -174,7 +174,7 @@ Notes:
 
 .. note::
 
-    Messages can be set in any :code:`HXRequest` at any point like this:
+    Messages can be set in any :code:`HxRequest` at any point like this:
 
     .. code-block:: python
 

--- a/docs/guide/hx_tags.rst
+++ b/docs/guide/hx_tags.rst
@@ -19,14 +19,14 @@ hx_get
     </button>
 
 - :code:`hx_get` takes in:
-    - The name of the :code:`HXRequest` that is being used
-    - An object if there is one that is associted with the :code:`HXRequest` (similar to Django's `UpdateView <https://docs.djangoproject.com/en/4.2/ref/class-based-views/generic-editing/#django.views.generic.edit.UpdateView>`_ )
+    - The name of the :code:`HxRequest` that is being used
+    - An object if there is one that is associted with the :code:`HxRequest` (similar to Django's `UpdateView <https://docs.djangoproject.com/en/4.2/ref/class-based-views/generic-editing/#django.views.generic.edit.UpdateView>`_ )
     - And kwargs
 
 Notes:
-    - If an object is passed in it is added as an attribute to the :code:`HXRequest` as :code:`hx_object` and can be accessed as :code:`self.hx_object`
-    - If :code:`hx_object_name` is not set on the :code:`HXRequest`, the object is passed into the template (:code:`GET_template` for :code:`get` requests or :code:`POST_template` for :code:`post` requests) as :code:`hx_object` and can be accessed in the template as :code:`{{ hx_object }}`
-    - Kwargs that are passed in are accessible in the :code:`HXRequest` (through :code:`**kwargs` in each method). They get passed into the template as part of the context, unless :code:`kwargs_as_context` is set to False then they are put in as :code:`hx_kwargs` and can be accessed as :code:`{{ hx_kwargs.key }}`
+    - If an object is passed in it is added as an attribute to the :code:`HxRequest` as :code:`hx_object` and can be accessed as :code:`self.hx_object`
+    - If :code:`hx_object_name` is not set on the :code:`HxRequest`, the object is passed into the template (:code:`GET_template` for :code:`get` requests or :code:`POST_template` for :code:`post` requests) as :code:`hx_object` and can be accessed in the template as :code:`{{ hx_object }}`
+    - Kwargs that are passed in are accessible in the :code:`HxRequest` (through :code:`**kwargs` in each method). They get passed into the template as part of the context, unless :code:`kwargs_as_context` is set to False then they are put in as :code:`hx_kwargs` and can be accessed as :code:`{{ hx_kwargs.key }}`
     - Besides for primitive types the object and the kwargs can be a :code:`model_instance` (an instance of a Django model) because a :code:`model_instance` gets serialized by :code:`hx_get`.
 
 .. warning::

--- a/docs/guide/messages.rst
+++ b/docs/guide/messages.rst
@@ -34,7 +34,7 @@ Notes:
 Setting a Message
 -----------------
 
-You can set a message anywhere within an :code:`HXRequest` the same way you would set a message in Django.
+You can set a message anywhere within an :code:`HxRequest` the same way you would set a message in Django.
 
 .. code-block:: python
 
@@ -50,11 +50,11 @@ Disabling Messages
 ------------------
 
 If :code:`HX_REQUESTS_USE_HX_MESSAGES`  is set to True, there are some default messages set in some of the :code:`HXRequests`.
-To disable messages on any :code:`HXRequest` set :code:`show_messages` to False
+To disable messages on any :code:`HxRequest` set :code:`show_messages` to False
 
 .. code-block:: python
 
-    class MyHXRequest(BaseHXRequest):
+    class MyHXRequest(BaseHxRequest):
         ...
         show_messages = False
 

--- a/docs/guide/modals.rst
+++ b/docs/guide/modals.rst
@@ -9,13 +9,13 @@ Using Modals
 
 .. code-block:: python
 
-    class ModalExample(HXModal):
+    class ModalExample(ModalHxRequest):
         name = "modal_example"
         body_template = "modal_body.html"
 
 Notes:
     - :code:`body_template` is used with modals instead of :code:`GET_template` since the :code:`GET_template` is acutally the the entire modal
-    - HxModal's return the entire modal not just the body template
+    - ModalHxRequest's return the entire modal not just the body template
 
 .. code-block:: html+django
 
@@ -38,7 +38,7 @@ To customize a modal, there are a few steps that need to be followed.
 #. Set the id of you modal to :code:`hx_modal_body` or set :code:`HX_REQUESTS_MODAL_BODY_ID` (a :code:`css` id for the modal body) in settings.
 #. Use an include for the body and add the title and modal_size_classes to the template. See the example below.
 #. Set a way for the modal to open when the modal template is rendered. See the modal example below.
-#. Set a way for the modal to close using the :code:`closeHxModal` event. See the modal example below
+#. Set a way for the modal to close using the :code:`closeModalHxRequest` event. See the modal example below
 #. Set a div with the id :code:`hx_modal_container` in the body of the page, this is where the modal will be rendered (the :code:`hx-target` of the request)
 
 .. tip::
@@ -88,7 +88,7 @@ Custom Modal Example
 Form Modals
 -----------
 
-:code:`hx-requests` has a built in form modal, :ref:`HXFormModal`. It takes care of the boilerplate needed to put a form in a modal.
+:code:`hx-requests` has a built in form modal, :ref:`FormModalHxRequest`. It takes care of the boilerplate needed to put a form in a modal.
 Additionally, it has features like keeping the modal open when the form in invalid so that the errors are displayed to the user.
 
 The page HTML
@@ -109,7 +109,7 @@ Notes:
 
 .. code-block:: python
 
-    class EditUserModal(HXFormModal):
+    class EditUserModal(FormModalHxRequest):
         name = "edit_user_modal"
         form_class = UserInfoForm
         body_template = 'form.html' # Used as the body of the modal
@@ -133,5 +133,5 @@ Notes:
     </div>
 
 Notes:
-    - The object is in this context as :code:`hx_object` because :code:`hx_object_name` is not set in the :code:`HXRequest` above
+    - The object is in this context as :code:`hx_object` because :code:`hx_object_name` is not set in the :code:`HxRequest` above
     - The object is passed in here becasue it is the model instance of the model form and it's the instance getting updated by the form

--- a/docs/guide/out_of_band.rst
+++ b/docs/guide/out_of_band.rst
@@ -11,9 +11,9 @@ Setting template to a list
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class UserInfoHXRequest(FormHXRequest):
+    class UserInfoHXRequest(FormHxRequest):
         name = "user_info_form"
         form_class = UserInfoForm
         GET_template = 'form.html'
@@ -37,9 +37,9 @@ Setting block to a list
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class UserInfoHXRequest(FormHXRequest):
+    class UserInfoHXRequest(FormHxRequest):
         name = "user_info_form"
         form_class = UserInfoForm
         GET_template = 'form.html'
@@ -64,9 +64,9 @@ Setting block to a dict
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import FormHXRequest
+    from hx_requests.hx_requests import FormHxRequest
 
-    class UserInfoHXRequest(FormHXRequest):
+    class UserInfoHXRequest(FormHxRequest):
         name = "user_info_form"
         form_class = UserInfoForm
         GET_template = 'form.html'

--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -2,7 +2,7 @@ Quickstart
 ==========
 
 The idea of hx-requests is that :code:`HXRequests` absorb all htmx requests.
-Define an :code:`HXRequest` (we'll get into how to do that in just a sec) and
+Define an :code:`HxRequest` (we'll get into how to do that in just a sec) and
 observe the magic of :code:`hx-requests`.
 
 - No need to define extra urls to handle these requests
@@ -42,11 +42,11 @@ The HTML
 
 Notes:
     - Using the :ref:`hx_get <hx_get>` template tag signifies that it's an :code:`hx-get`
-    - 'get_user_info' is the name of this :code:`HXRequest`. See below to understand what that means
+    - 'get_user_info' is the name of this :code:`HxRequest`. See below to understand what that means
     - The goal of this :code:`hx-get` is to render a user info card into the empty div
 
 
-Create the HXRequest
+Create the HxRequest
 ~~~~~~~~~~~~~~~~~~~~
 
 Create an :code:`hx_requests.py` file
@@ -56,14 +56,14 @@ Create an :code:`hx_requests.py` file
     All :code:`HXRequests` must be defined inside an :code:`hx_requests.py` file, and the :code:`hx_requests.py`
     files must live inside an app that's included in Django's :code:`INSTALLED_APPS`.
 
-| Create the HXRequest.
-| The :code:`hx-get` will get directed to this :code:`HXRequest`.
+| Create the HxRequest.
+| The :code:`hx-get` will get directed to this :code:`HxRequest`.
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import BaseHXRequest
+    from hx_requests.hx_requests import BaseHxRequest
 
-    class GetUserInfo(BaseHXRequest):
+    class GetUserInfo(BaseHxRequest):
         name = "get_user_info"
         GET_template = "user_info_card.html"
 
@@ -82,7 +82,7 @@ Notes:
 Summary
 ~~~~~~~
 
-| Htmx requests are routed to the :code:`HXRequest` that matches the name (1st argument) passed into the :code:`hx_get` template tag. In this example 'get_user_info'. That's how the :code:`hx-get` is routed to :code:`GetUserInfo`.
+| Htmx requests are routed to the :code:`HxRequest` that matches the name (1st argument) passed into the :code:`hx_get` template tag. In this example 'get_user_info'. That's how the :code:`hx-get` is routed to :code:`GetUserInfo`.
 |
 | The request returns the html of the :code:`GET_template`.
 
@@ -134,7 +134,7 @@ Notes:
     - The goal of this :code:`hx-post` is to change the signed in user's email to the value of the input replace the email address in the div with the updated email
 
 
-Create the HXRequest
+Create the HxRequest
 ~~~~~~~~~~~~~~~~~~~~
 
 Create an :code:`hx_requests.py` file
@@ -144,14 +144,14 @@ Create an :code:`hx_requests.py` file
     All :code:`HXRequests` must be defined inside an :code:`hx_requests.py` file, and the :code:`hx_requests.py`
     files must live inside an app that's included in Django's :code:`INSTALLED_APPS`.
 
-| Create the HXRequest.
-| The :code:`hx-post` will get directed to this :code:`HXRequest`.
+| Create the HxRequest.
+| The :code:`hx-post` will get directed to this :code:`HxRequest`.
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import BaseHXRequest
+    from hx_requests.hx_requests import BaseHxRequest
 
-    class ChangeEmail(BaseHXRequest):
+    class ChangeEmail(BaseHxRequest):
         name = "change_email"
         POST_template = "email.html"
 
@@ -173,7 +173,7 @@ Notes:
 Summary
 ~~~~~~~
 
-| Htmx requests are routed to the :code:`HXRequest` that matches the name (1st argument) passed into the :code:`hx_post` template tag. In this example 'change_email'. That's how the :code:`hx-post` is routed to :code:`ChangeEmail`.
+| Htmx requests are routed to the :code:`HxRequest` that matches the name (1st argument) passed into the :code:`hx_post` template tag. In this example 'change_email'. That's how the :code:`hx-post` is routed to :code:`ChangeEmail`.
 |
 | The request returns the html of the :code:`POST_template`.
 
@@ -189,9 +189,9 @@ a simple way to add context to them.
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import BaseHXRequest
+    from hx_requests.hx_requests import BaseHxRequest
 
-    class MyHXRequest(BaseHXRequest):
+    class MyHXRequest(BaseHxRequest):
         ...
 
         def get_context_data(self, **kwargs):
@@ -204,9 +204,9 @@ instead override :code:`get_post_context_data`
 
 .. code-block:: python
 
-    from hx_requests.hx_requests import BaseHXRequest
+    from hx_requests.hx_requests import BaseHxRequest
 
-    class MyHXRequest(BaseHXRequest):
+    class MyHXRequest(BaseHxRequest):
         ...
 
         def get_post_context_data(self, **kwargs):

--- a/hx_requests/hx_registry.py
+++ b/hx_requests/hx_registry.py
@@ -4,7 +4,7 @@ import threading
 
 from django.apps import apps
 
-from hx_requests.hx_requests import BaseHXRequest
+from hx_requests.hx_requests import BaseHxRequest
 
 
 class HXRequestRegistry:
@@ -33,7 +33,7 @@ class HXRequestRegistry:
                             continue
                         cls._processed_classes.add(obj)
 
-                        if issubclass(obj, BaseHXRequest) and getattr(
+                        if issubclass(obj, BaseHxRequest) and getattr(
                             obj, "name", None
                         ):
                             cls.register_hx_request(obj.name, obj)
@@ -45,7 +45,7 @@ class HXRequestRegistry:
     @classmethod
     def register_hx_request(cls, name, hx_request_class):
         if name in cls._registry:
-            raise Exception(f"Duplicate HXRequest name found: {name}")
+            raise Exception(f"Duplicate HxRequest name found: {name}")
         cls._registry[name] = hx_request_class
 
     @classmethod

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -23,14 +23,14 @@ class Renderer:
         return render_to_string(template_name, context, request)
 
 
-class BaseHXRequest:
+class BaseHxRequest:
     """
     Base class for HXRequests. Class to be used for basic GET and POST requests.
 
     Attributes
     ----------
     name : str
-         Unique name that needs to be matched in the template tag rendering the HXRequest
+         Unique name that needs to be matched in the template tag rendering the HxRequest
     hx_object_name : str, optional
         Name that the hx_object is passed into the context with
     GET_template : str,list, optional
@@ -57,8 +57,8 @@ class BaseHXRequest:
         If True and there is a message set and settings.HX_REQUESTS_USE_HX_MESSAGES is True
         then the set message is displayed
     get_views_context: bool
-        If True, the context from the view is added to the context of the HXRequest
-        If False, only the context from the HXRequest is used, potentially improving performance
+        If True, the context from the view is added to the context of the HxRequest
+        If False, only the context from the HxRequest is used, potentially improving performance
         by not needing to call the view's get_context_data method.
     kwargs_as_context: bool
         If True, the kwargs are added into the context directly.
@@ -292,12 +292,12 @@ class BaseHXRequest:
         return self._get_response(**kwargs)
 
 
-class FormHXRequest(BaseHXRequest):
+class FormHxRequest(BaseHxRequest):
     """
     HXRequests class to be used for forms that helps with some of the boiler plate.
     It's loosely based on Django's FormView and UpdateView.
 
-    Every FormHXRequest must have a form associated with it. The form is
+    Every FormHxRequest must have a form associated with it. The form is
     passed into the context and is also accessible within the class as
     self.form.
 
@@ -313,7 +313,7 @@ class FormHXRequest(BaseHXRequest):
     Attributes
     ----------
     form_class : Form
-        Class of the form attached to the FormHXRequest
+        Class of the form attached to the FormHxRequest
     add_form_errors_to_error_message : bool
         If True adds the form's validation errors to the error message on form_invalid
     set_initial_from_kwargs : bool
@@ -446,11 +446,11 @@ class FormHXRequest(BaseHXRequest):
         return errors
 
 
-class DeleteHXRequest(BaseHXRequest):
+class DeleteHxRequest(BaseHxRequest):
     """
-    HXRequest for deleting objects.
+    HxRequest for deleting objects.
 
-    The object passed into a DeleteHXRequest is deleted.
+    The object passed into a DeleteHxRequest is deleted.
     Override handle_delete for custom behavior.
     """
 
@@ -482,7 +482,7 @@ class DeleteHXRequest(BaseHXRequest):
         return message
 
 
-class HXModal(BaseHXRequest):
+class ModalHxRequest(BaseHxRequest):
     """
     A generic modal that can be used without needing to create a class that inherits from this one.
     It can be used by passing in title and body into the template tag as kwargs and passing in
@@ -511,7 +511,7 @@ class HXModal(BaseHXRequest):
         modal_template = getattr(settings, "HX_REQUESTS_MODAL_TEMPLATE", None)
         if not modal_template:
             raise Exception(
-                "HX_REQUESTS_MODAL_TEMPLATE needs to be set in settings to use HXModal"
+                "HX_REQUESTS_MODAL_TEMPLATE needs to be set in settings to use ModalHxRequest"
             )
         return modal_template
 
@@ -521,7 +521,7 @@ class HXModal(BaseHXRequest):
         """
         self.GET_template = self.modal_template
         if not self.body_template:
-            raise Exception("body_template is required when using HXModal")
+            raise Exception("body_template is required when using ModalHxRequest")
 
         return super().get(request, *args, **kwargs)
 
@@ -538,11 +538,11 @@ class HXModal(BaseHXRequest):
         return context
 
 
-class HXFormModal(HXModal, FormHXRequest):
+class FormModalHxRequest(ModalHxRequest, FormHxRequest):
     """
     A modal to be used with a form.
-    You need to create an HXRequest class that inherits from this one
-    and set the needed attributes for a FormHXRequest.
+    You need to create an HxRequest class that inherits from this one
+    and set the needed attributes for a FormHxRequest.
 
     If the form is invalid the modal stays open and the form contains the validation
     errors. If the form is valid the modal will close.
@@ -563,7 +563,7 @@ class HXFormModal(HXModal, FormHXRequest):
     def get_triggers(self, **kwargs) -> list:
         triggers = super().get_triggers(**kwargs)
         if self.is_post_request and self.form.is_valid() and self.close_modal_on_save:
-            triggers.append("closeHxModal")
+            triggers.append("closeModalHxRequest")
         return triggers
 
     def get_headers(self, **kwargs) -> Dict:
@@ -579,7 +579,7 @@ class HXFormModal(HXModal, FormHXRequest):
         POST_template the GET_template is returned (the form
         now contains the validation errors.)
 
-        Overrides the get_response_html method from FormHXRequest
+        Overrides the get_response_html method from FormHxRequest
         to use the body_template instead of the GET_template.
         """
         if self.is_post_request and self.form.is_valid() is False:

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -15,7 +15,7 @@ class HtmxViewMixin:
     """
     Mixin to be added to views that are using HXRequests.
     Hijacks the get and post to route them to the proper
-    HXRequest.
+    HxRequest.
     """
 
     hx_requests: Dict = []
@@ -26,7 +26,7 @@ class HtmxViewMixin:
         # request method isn't on the approved list.
         if request.method.lower() in self.http_method_names:
             handler_class = self
-            # If it's an HTMX request, use the HXRequest class to handle the request
+            # If it's an HTMX request, use the HxRequest class to handle the request
             # otherwise, use the view class to handle the request.
             if is_htmx_request(request):
                 kwargs.update(self.get_hx_extra_kwargs(request))
@@ -43,7 +43,7 @@ class HtmxViewMixin:
         hx_request_class = HXRequestRegistry.get_hx_request(hx_request_name)
         if not hx_request_class:
             raise Http404(
-                f"No HXRequest found with the name {hx_request_name}. Are you sure it's spelled correctly?"
+                f"No HxRequest found with the name {hx_request_name}. Are you sure it's spelled correctly?"
             )
         return hx_request_class()
 


### PR DESCRIPTION
BREAKING CHANGE: Imports and references to the classes need to be updated.
BaseHXRequest -> BaseHxRequest
FormHXRequest -> FormHxRequest
DeleteHxRequest -> DeleteHxRequest
HXModal -> ModalHxRequest
HXFormModal -> FormModalHxRequest