### PR TITLE
fix: Revert close modal trigger name to what it was before

### DIFF
--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -540,7 +540,7 @@ class FormModalHxRequest(ModalHxRequest, FormHxRequest):
     def get_triggers(self, **kwargs) -> list:
         triggers = super().get_triggers(**kwargs)
         if self.is_post_request and self.form.is_valid() and self.close_modal_on_save:
-            triggers.append("closeModalHxRequest")
+            triggers.append("closeHxModal")
         return triggers
 
     def get_headers(self, **kwargs) -> Dict:


### PR DESCRIPTION
Global find and replace bug 🙈