### PR TITLE
feat: Support passing details with HX-Trigger headers

### DIFF
--- a/docs/how_tos/add_headers.rst
+++ b/docs/how_tos/add_headers.rst
@@ -46,6 +46,37 @@ Since triggers are commonly used, a helper method is available to add them to th
             triggers.append("some_trigger")
             return triggers
 
+Hx-Trigger With Details
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can pass details along with a trigger by using a dict instead of a string.
+When any trigger carries details, the header is automatically formatted as a JSON object
+per the `HX-Trigger spec <https://htmx.org/headers/hx-trigger/>`_.
+
+.. code-block:: python
+
+    from hx_requests.hx_requests import BaseHxRequest
+
+    class MyHxRequest(BaseHxRequest):
+        ....
+
+        def get_triggers(self, **kwargs):
+            triggers = super().get_triggers(**kwargs)
+            triggers.append({"showMessage": {"level": "info", "message": "Saved!"}})
+            return triggers
+
+You can also mix plain triggers and triggers with details:
+
+.. code-block:: python
+
+    def get_triggers(self, **kwargs):
+        triggers = super().get_triggers(**kwargs)
+        triggers.append("refreshList")
+        triggers.append({"showMessage": "Item saved successfully"})
+        return triggers
+
+This produces the header: ``HX-Trigger: {"refreshList": true, "showMessage": "Item saved successfully"}``
+
 Refresh and Redirect
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -1,6 +1,7 @@
 import contextlib
+import json
 from functools import partial
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from django.conf import settings
 from django.contrib import messages
@@ -192,16 +193,44 @@ class BaseHxRequest:
         if self.no_swap:
             headers["HX-Reswap"] = "none"
 
-        triggers = self.get_triggers(**kwargs)
+        triggers = self.format_triggers(**kwargs)
         if triggers:
-            headers["HX-Trigger"] = ", ".join(triggers)
+            headers["HX-Trigger"] = triggers
         return headers
 
-    def get_triggers(self, **kwargs) -> list:
+    def get_triggers(self, **kwargs) -> List[Union[str, dict]]:
         """
         Override to set the triggers for the response.
+
+        Return a list of triggers. Each trigger can be:
+        - A string for a simple trigger (e.g. ``"myEvent"``).
+        - A dict to pass details with the trigger
+          (e.g. ``{"showMessage": {"level": "info", "message": "Saved!"}}``).
+
+        When any dict is present, the header is formatted as a JSON object
+        per the `HX-Trigger response header spec <https://htmx.org/headers/hx-trigger/>`_.
         """
         return []
+
+    def format_triggers(self, **kwargs) -> str:
+        """
+        Format triggers for the ``HX-Trigger`` header.
+
+        If all triggers are plain strings, they are comma-separated.
+        If any trigger carries details (dict), the header is JSON-encoded.
+        """
+        triggers = self.get_triggers(**kwargs)
+        has_details = any(isinstance(t, dict) for t in triggers)
+        if not has_details:
+            return ", ".join(triggers)
+
+        merged = {}
+        for trigger in triggers:
+            if isinstance(trigger, str):
+                merged[trigger] = True
+            elif isinstance(trigger, dict):
+                merged.update(trigger)
+        return json.dumps(merged)
 
     def get_response_html(self, **kwargs) -> str:
         """


### PR DESCRIPTION
## Summary

Adds support for passing event details through `HX-Trigger` response headers when overriding `get_triggers`, per the [htmx HX-Trigger spec](https://htmx.org/headers/hx-trigger/).

## Changes

- `get_triggers` now accepts dicts alongside strings in the returned list
- New public `format_triggers` method handles formatting:
  - All strings → comma-separated (backward compatible)
  - Any dicts present → JSON-encoded object
- Updated docs with examples for triggers with details

## Usage

```python
def get_triggers(self, **kwargs):
    triggers = super().get_triggers(**kwargs)
    triggers.append("refreshList")
    triggers.append({"showMessage": {"level": "info", "message": "Saved!"}})
    return triggers
# HX-Trigger: {"refreshList": true, "showMessage": {"level": "info", "message": "Saved!"}}
```

Fully backward compatible — existing code returning `list[str]` produces identical output.