### PR TITLE
feat: return None from form/delete hooks and add form-invalid message…

### DIFF
--- a/docs/explanation/form_hx_requests.rst
+++ b/docs/explanation/form_hx_requests.rst
@@ -26,6 +26,9 @@ If you want to do something else you can override the :code:`form_valid` method,
 rendered back to the :code:`GET_template` so that the form will be still visible but now with the errors. The error message can be
 suppressed by setting :code:`show_form_invalid_message` to False (useful when the form already renders inline field errors).
 
+When overriding :code:`form_valid` or :code:`form_invalid` you do not need to return anything; returning :code:`None` lets the
+response be built for you. Return an :code:`HttpResponse` only when you want to short-circuit with custom output.
+
 Other built in behavior includes support for setting :ref:`form_kwargs <How To Add Form Kwargs>` (even the ability to automatically set from the :ref:`template tag <Adding Initial Form Values From The Template>`),
 
 hx_object

--- a/docs/explanation/form_hx_requests.rst
+++ b/docs/explanation/form_hx_requests.rst
@@ -23,7 +23,8 @@ On POST the :code:`form_valid` method is called if the form is valid and the :co
 If you want to do something else you can override the :code:`form_valid` method, ie like sending an email.
 
 :code:`form_invalid` by default sets a :ref:`message <How To Set Messages>` and returns the form with the errors and it does this by changing the template
-rendered back to the :code:`GET_template` so that the form will be still visible but now with the errors.
+rendered back to the :code:`GET_template` so that the form will be still visible but now with the errors. The error message can be
+suppressed by setting :code:`show_form_invalid_message` to False (useful when the form already renders inline field errors).
 
 Other built in behavior includes support for setting :ref:`form_kwargs <How To Add Form Kwargs>` (even the ability to automatically set from the :ref:`template tag <Adding Initial Form Values From The Template>`),
 

--- a/docs/how_tos/use_messages.rst
+++ b/docs/how_tos/use_messages.rst
@@ -52,19 +52,19 @@ You can set a message anywhere within an :code:`HxRequest` the same way you woul
 
     from django.contrib import messages
 
-    def form_valid(self, **kwargs) -> str:
+    def form_valid(self, **kwargs):
         self.form.save()
 
         # Set a message
         messages.success(self.request, "Form saved successfully")
 
-        return ...
-
-    def form_invalid(self, **kwargs) -> str:
+    def form_invalid(self, **kwargs):
         # Set a message
         messages.error(self.request, "Form is invalid")
 
-        return ...
+:code:`form_valid` and :code:`form_invalid` do not need to return anything. When they
+return :code:`None` the response is built for you. Return an :code:`HttpResponse` only
+if you need to short-circuit with custom output.
 
 Disabling Messages
 ~~~~~~~~~~~~~~~~~~

--- a/docs/how_tos/use_messages.rst
+++ b/docs/how_tos/use_messages.rst
@@ -78,6 +78,16 @@ To disable messages on any :code:`HxRequest` set :code:`show_messages` to False
         ...
         show_messages = False
 
+On a :code:`FormHxRequest`, an error message is set by default when the form is invalid.
+If the form already renders inline field errors this banner can be redundant. Set
+:code:`show_form_invalid_message` to False to suppress it without overriding :code:`form_invalid`.
+
+.. code-block:: python
+
+    class MyHxRequest(FormHxRequest):
+        ...
+        show_form_invalid_message = False
+
 Tip
 ~~~
 

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -353,11 +353,15 @@ class FormHxRequest(BaseHxRequest):
     set_initial_from_kwargs : bool
         If True sets the initial values in the form from the kwargs as long as the key
         matches a field in the form
+    show_form_invalid_message : bool
+        If True (default) sets an error message on form_invalid. Set to False to suppress it
+        (useful when the form already renders inline field errors).
     """
 
     form_class: Form = None
     add_form_errors_to_error_message: bool = False
     set_initial_from_kwargs: bool = False
+    show_form_invalid_message: bool = True
 
     def get_context_data(self, **kwargs) -> Dict:
         """
@@ -397,10 +401,11 @@ class FormHxRequest(BaseHxRequest):
 
     def form_invalid(self, **kwargs) -> HttpResponse:
         """
-        Sets an error message.
+        Sets an error message unless ``show_form_invalid_message`` is False.
         Returns self._get_response. Override to add custom behavior.
         """
-        messages.error(self.request, self.get_error_message(**kwargs))
+        if self.show_form_invalid_message:
+            messages.error(self.request, self.get_error_message(**kwargs))
         return self._get_response(**kwargs)
 
     def get_response_html(self, **kwargs):

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -1,7 +1,7 @@
 import contextlib
 import json
 from functools import partial
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from django.conf import settings
 from django.contrib import messages
@@ -382,31 +382,35 @@ class FormHxRequest(BaseHxRequest):
         """
         If the form is valid form_valid.
         If invalid calls form_invalid.
+
+        Builds the response from ``_get_response`` unless ``form_valid`` /
+        ``form_invalid`` return their own ``HttpResponse``.
         """
         self.form = self.form_class(**self.get_form_kwargs(**kwargs))
 
-        if self.form.is_valid():
-            return self.form_valid(**kwargs)
-        else:
-            return self.form_invalid(**kwargs)
+        response = self.form_valid(**kwargs) if self.form.is_valid() else self.form_invalid(**kwargs)
 
-    def form_valid(self, **kwargs) -> HttpResponse:
+        return response if response is not None else self._get_response(**kwargs)
+
+    def form_valid(self, **kwargs) -> Optional[HttpResponse]:
         """
         Saves the form and sets a success message.
-        Returns self._get_response. Override to add custom behavior.
+
+        Return ``None`` (default) to let ``post`` build the standard response,
+        or return an ``HttpResponse`` to short-circuit with custom output.
         """
         self.form.save()
         messages.success(self.request, self.get_success_message(**kwargs))
-        return self._get_response(**kwargs)
 
-    def form_invalid(self, **kwargs) -> HttpResponse:
+    def form_invalid(self, **kwargs) -> Optional[HttpResponse]:
         """
         Sets an error message unless ``show_form_invalid_message`` is False.
-        Returns self._get_response. Override to add custom behavior.
+
+        Return ``None`` (default) to let ``post`` build the standard response,
+        or return an ``HttpResponse`` to short-circuit with custom output.
         """
         if self.show_form_invalid_message:
             messages.error(self.request, self.get_error_message(**kwargs))
-        return self._get_response(**kwargs)
 
     def get_response_html(self, **kwargs):
         """
@@ -494,17 +498,22 @@ class DeleteHxRequest(BaseHxRequest):
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Calls delete on the hx_object.
-        """
-        return self.delete(**kwargs)
 
-    def delete(self, **kwargs) -> str:
+        Builds the response from ``_get_response`` unless ``delete`` returns
+        its own ``HttpResponse``.
+        """
+        response = self.delete(**kwargs)
+        return response if response is not None else self._get_response(**kwargs)
+
+    def delete(self, **kwargs) -> Optional[HttpResponse]:
         """
         Deletes the hx_object and sets a success message.
-        Override to add custom behavior.
+
+        Return ``None`` (default) to let ``post`` build the standard response,
+        or return an ``HttpResponse`` to short-circuit with custom output.
         """
         self.hx_object.delete()
         messages.success(self.request, self.get_success_message(**kwargs))
-        return self._get_response(**kwargs)
 
     def get_success_message(self, **kwargs) -> str:
         """


### PR DESCRIPTION
… opt-out

form_valid, form_invalid and DeleteHxRequest.delete previously had to end with `return self._get_response(**kwargs)`. Because _get_response is private and not meant to be called by users, every override had to remember to return it or the response would silently break. It also created a latent bug: _get_response calls get_messages(), which *consumes* the message store, so an override that called super().form_valid() and then built its own response would render with the messages already drained.

These hooks now do their work and return None, and post() builds the response via _get_response(). Returning an HttpResponse still short-circuits, so existing overrides that return _get_response() (or any response) keep working unchanged and _get_response runs exactly once.

Also adds a `show_form_invalid_message` attribute (default True) to FormHxRequest. form_invalid always set an error message, which is redundant when the form already renders inline field errors; set it to False to suppress the banner without having to override form_invalid.