### PR TITLE
feat!: sign the serialized round-trip token

### DIFF
--- a/docs/explanation/how_hx_requests_works.rst
+++ b/docs/explanation/how_hx_requests_works.rst
@@ -11,10 +11,18 @@ When using the :ref:`hx_get <Hx Tags>` and :ref:`hx_post <Hx Tags>` template tag
 
 
 #. The URL of the request is set to the current page's URL.
-#. An :code:`hx_request_name`` GET parameter is added to the request URL (based on the name passed to the template tag).
-#. When the request reaches the view, :code:`HtmxViewMixin` checks if the request is an HTMX request and if the :code:`hx_request_name` is in the request
-   and routes the request to the :code:`HxRequest` with the matching name.
+#. A single :code:`hx` GET parameter is added to the request URL. It carries the
+   :code:`HxRequest` name (along with the serialized object and kwargs).
+#. When the request reaches the view, :code:`HtmxViewMixin` reads the name from
+   the :code:`hx` parameter and routes the request to the :code:`HxRequest` with
+   the matching name.
 #. The :code:`HxRequest` processes the request and returns an Html response.
+
+.. note::
+
+    The :code:`hx` parameter is a signed token, not loose query params — see
+    :ref:`Object Serialization` for what it packs and
+    :ref:`Why HxRequest Security Is Needed` for why it is signed.
 
 
 Why Not Just Use A URL Router?

--- a/docs/explanation/object_serialization.rst
+++ b/docs/explanation/object_serialization.rst
@@ -12,7 +12,8 @@ Serializing Model Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a model instance is serialized, it is converted into a structured string format
-that includes the prefix :code:`model_instance`, to differentiate from other URL parameters, the app label, model name, and primary key.
+that includes the prefix :code:`model_instance`, to distinguish it from a plain JSON
+value, followed by the app label, model name, and primary key.
 
 For example, a :code:`User` instance with :code:`pk=5` in the :code:`auth` app
 would be represented as:
@@ -40,13 +41,19 @@ This process ensures that Django objects can be reconstructed properly when hand
 Handling kwargs Serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each keyword argument is prefixed with :code:`___` to differentiate it from standard query parameters.
-When deserializing, the prefix is removed, and values are restored to their original form.
+Each keyword argument is prefixed with :code:`___` inside the token so it can be
+told apart from any loose query parameters. When deserializing, the prefix is
+removed, and values are restored to their original form.
 
 This allows :code:`hx_requests` to safely pass complex parameters in HTMX requests.
 
 .. note::
 
-    Since keyword arguments (:code:`kwargs`) are prefixed with :code:`___` during serialization, they are not recognized as standard query parameters.
-    If you need to pass a GET parameter through an HTMX request, use the :code:`hx-include` or :code:`hx-vals` attribute instead of a passing as a :code:`kwarg`.
-    For example, when implementing pagination, the :code:`page` parameter must be sent as a standard GET parameter. Passing it as a :code:`kwarg` will result in it being prefixed and ignored by the request handler.
+    Kwargs live *inside* the signed token, not on the query string — so a kwarg
+    is never read as a standard GET parameter.
+    If you need to pass a real GET parameter through an HTMX request, use the
+    :code:`hx-include` or :code:`hx-vals` attribute instead of passing it as a :code:`kwarg`.
+    For example, when implementing pagination, the :code:`page` parameter must be sent as a standard GET parameter. Passing it as a :code:`kwarg` will bury it in the token and it will be ignored by the request handler.
+
+    To read the kwargs back out of the token in your own view code, see
+    :ref:`Reading The Name, Object, And Kwargs`.

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -58,6 +58,16 @@ by the scoping controls here — it comes from requiring authentication
 routes through. The scoping controls below are a third axis: which handlers a
 given view or app may run at all.
 
+.. warning::
+
+    None of the layers on this page authorize *individual users*. Signing,
+    path-binding, and app/handler scoping establish that a request is genuine, on
+    its own page, and allowed for the view — **not** that *this user* may perform
+    the action. To restrict who can run a handler you still have to require
+    authentication (:code:`HX_REQUESTS_REQUIRE_AUTH`) and enforce your own
+    permission checks on the view each :code:`HxRequest` routes through, exactly
+    as you would protect any other view.
+
 
 The Threat: Replaying a Valid Token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -2,12 +2,22 @@ Why HxRequest Security Is Needed
 --------------------------------
 
 HxRequests make it easy to build modular, dynamic interfaces using HTMX.
-However, because they are registered globally, any request can be triggered
-from any view by passing the right :code:`hx_request_name`— unless you explicitly
-restrict it.
+Because they are registered globally, controlling *which* view may invoke *which*
+handler still matters — that is what the controls on this page provide.
 
 This page explains **why these security controls exist**, the risks they prevent,
 and the principles behind their design.
+
+.. note::
+
+    **Request signing comes first.** The :code:`HxRequest` name, object, and
+    kwargs are delivered in a single HMAC-signed :code:`hx` token, so a client
+    **cannot forge or hand-craft** a request for an arbitrary handler — a
+    missing or tampered token is rejected with :code:`Http404` before any
+    routing happens. The controls below are the *next* layer: they scope which
+    registered handlers a given view/app is willing to run, which is what still
+    governs a token that was issued legitimately somewhere and then replayed
+    against a view that shouldn't accept it.
 
 See also: :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 
@@ -15,50 +25,48 @@ See also: :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 The Problem
 ~~~~~~~~~~~
 
-Without validation, any page or script can issue a request like:
+Signing stops a client from *hand-crafting* a request for an arbitrary handler
+— a URL like :code:`/home/?hx=<made-up-token>` is rejected because the token
+won't verify. What signing does **not** decide is *scope*: which registered
+handlers a given view is willing to run.
 
-.. code-block:: html+django
-
-    <button hx-get="/some/unrelated/view/?hx_request_name=delete_all_records_hx">
-        Run Dangerous Request
-    </button>
-
-If :code:`delete_all_records_hx` exists anywhere in your project,
-it would execute—even if the current view or user shouldn’t have access to it.
-
-This can happen because the :code:`HtmxViewMixin` automatically routes
-based on the :code:`hx_request_name` parameter. As long as the target view
-includes this mixin, **any page** pointing to that view can call
-any registered :code:`HxRequest`, regardless of where it was intended to run.
+Because :code:`HtmxViewMixin` routes any HTMX request by the (verified) name
+inside the token, **any view that includes the mixin** is a potential entry
+point for any registered :code:`HxRequest` — provided a valid token for that
+handler exists. Tokens are minted server-side by the template tags, so the risk
+is a legitimately-issued token being **replayed against a view where it was
+never meant to run**.
 
 For example, you may design an :code:`HxRequest` such as
 :code:`delete_all_records_hx` to be used **only** from an internal admin page.
-But a malicious user (or even a public page) could send the same request from:
+If a valid token for it is rendered somewhere a user can see, nothing about the
+signature alone stops them from replaying it against an unrelated view:
 
 .. code-block:: html
 
-    <button hx-get="/home/?hx_request_name=delete_all_records_hx">Run Delete</button>
+    <button hx-post="/home/?hx=<a-real-token-for-delete_all_records_hx>">Run Delete</button>
 
 If :code:`/home` is a simple, public-facing view that includes
-the :code:`HtmxViewMixin`, and does not require authentication,
-this button would still reach and execute the deletion logic.
+the :code:`HtmxViewMixin`, and does not itself require authentication or scope
+its handlers, this request would still reach and execute the deletion logic.
 
 In other words:
-    - The actual page or route doesn’t matter — any page that uses the mixin
-      becomes a potential gateway for any registered HxRequest.
-    - A completely unrelated view (like a homepage) could call an
-      administrative HxRequest simply by passing its name in the query string.
-    - Authentication or permission checks on the original intended view
-      (where the HxRequest was meant to run) are **bypassed entirely**.
+    - The actual page or route doesn’t matter — any view that uses the mixin
+      becomes a potential gateway for any registered HxRequest it doesn't scope.
+    - An unrelated view (like a homepage) could run an administrative HxRequest
+      if it neither restricts which handlers it accepts nor enforces auth.
+    - Authentication or permission checks on the *originally intended* view
+      (where the HxRequest was meant to run) do not automatically apply here.
 
-This means:
-    - Users could trigger private or destructive actions from public pages.
+This means, without the controls below:
+    - Users could replay private or destructive actions from public pages.
     - Views could unintentionally expose data or behavior from other apps.
-    - Third-party templates, plugins, or unreviewed code could invoke internal logic
-      by referencing the right :code:`hx_request_name`.
+    - Third-party templates, plugins, or unreviewed code could invoke internal
+      logic from views that never scoped their handlers.
 
-Without additional security controls, any :code:`hx_request_name` becomes a
-global entry point into your application’s internal request logic.
+So while signing removes the forging vector, app-isolation and per-view scoping
+remain the layer that keeps a registered handler from becoming a global entry
+point into your application’s internal request logic.
 
 Design Goals
 ~~~~~~~~~~~~
@@ -74,11 +82,11 @@ The new HxRequest security layer enforces:
 What Happens Without Controls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you remove these checks, anyone who knows (or guesses) an :code:`hx_request_name`
-can:
+If you remove these checks, anyone holding a valid token for an
+:code:`HxRequest` (one rendered on any page they can reach) can:
 
-    - Trigger arbitrary requests from unrelated views.
-    - Modify or delete data outside their intended scope.
+    - Replay that request against unrelated views.
+    - Modify or delete data outside its intended scope.
     - Execute sensitive operations from unprotected endpoints.
 
 
@@ -120,11 +128,10 @@ Typical valid cases include:
 Summary
 ~~~~~~~
 
-Without these controls, :code:`hx_request_name` effectively exposes
-a remote-call interface to your entire Django project.
-
-The HxRequest security layer ensures this system respects
-application boundaries and explicit trust.
+Signing ensures a request's name, object, and kwargs can't be forged. On top of
+that, the controls here ensure a registered handler doesn't become a remote-call
+interface to your entire Django project by respecting application boundaries and
+explicit trust.
 
 Continue to :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 for configuration examples.

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -1,3 +1,5 @@
+.. _why-hxrequest-security:
+
 Why HxRequest Security Is Needed
 --------------------------------
 
@@ -5,8 +7,8 @@ HxRequests make it easy to build modular, dynamic interfaces using HTMX.
 Because they are registered globally, controlling *which* view may invoke *which*
 handler still matters — that is what the controls on this page provide.
 
-This page explains **why these security controls exist**, the risks they prevent,
-and the principles behind their design.
+This page explains the risk these controls prevent, the model that prevents it,
+and when it is safe to relax it.
 
 .. note::
 
@@ -14,16 +16,15 @@ and the principles behind their design.
     kwargs are delivered in a single HMAC-signed :code:`hx` token, so a client
     **cannot forge or hand-craft** a request for an arbitrary handler — a
     missing or tampered token is rejected with :code:`Http404` before any
-    routing happens. The controls below are the *next* layer: they scope which
-    registered handlers a given view/app is willing to run, which is what still
-    governs a token that was issued legitimately somewhere and then replayed
-    against a view that shouldn't accept it.
+    routing happens. Everything on this page is the *next* layer: it governs a
+    token that was issued legitimately somewhere and then replayed against a
+    view that shouldn't accept it.
 
 See also: :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 
 
-The Problem
-~~~~~~~~~~~
+The Threat: Replaying a Valid Token
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Signing stops a client from *hand-crafting* a request for an arbitrary handler
 — a URL like :code:`/home/?hx=<made-up-token>` is rejected because the token
@@ -34,8 +35,8 @@ Because :code:`HtmxViewMixin` routes any HTMX request by the (verified) name
 inside the token, **any view that includes the mixin** is a potential entry
 point for any registered :code:`HxRequest` — provided a valid token for that
 handler exists. Tokens are minted server-side by the template tags, so the risk
-is a legitimately-issued token being **replayed against a view where it was
-never meant to run**.
+isn't forgery; it's a legitimately-issued token being **replayed against a view
+where it was never meant to run**.
 
 For example, you may design an :code:`HxRequest` such as
 :code:`delete_all_records_hx` to be used **only** from an internal admin page.
@@ -46,52 +47,34 @@ signature alone stops them from replaying it against an unrelated view:
 
     <button hx-post="/home/?hx=<a-real-token-for-delete_all_records_hx>">Run Delete</button>
 
-If :code:`/home` is a simple, public-facing view that includes
-the :code:`HtmxViewMixin`, and does not itself require authentication or scope
-its handlers, this request would still reach and execute the deletion logic.
+If :code:`/home` is a simple, public-facing view that includes the
+:code:`HtmxViewMixin` and neither scopes its handlers nor enforces auth, this
+request would still reach and execute the deletion logic. The consequences:
 
-In other words:
-    - The actual page or route doesn’t matter — any view that uses the mixin
-      becomes a potential gateway for any registered HxRequest it doesn't scope.
-    - An unrelated view (like a homepage) could run an administrative HxRequest
-      if it neither restricts which handlers it accepts nor enforces auth.
-    - Authentication or permission checks on the *originally intended* view
-      (where the HxRequest was meant to run) do not automatically apply here.
+    - The route doesn't matter — any view using the mixin is a potential gateway
+      for any registered :code:`HxRequest` it doesn't scope.
+    - Permission checks on the *originally intended* view do not automatically
+      apply where the token is replayed.
+    - So users could replay private or destructive actions from public pages, and
+      third-party or unreviewed templates could invoke internal logic from views
+      that never scoped their handlers.
 
-This means, without the controls below:
-    - Users could replay private or destructive actions from public pages.
-    - Views could unintentionally expose data or behavior from other apps.
-    - Third-party templates, plugins, or unreviewed code could invoke internal
-      logic from views that never scoped their handlers.
+Signing removes the *forging* vector; app-isolation and per-view scoping are the
+layer that keeps a registered handler from becoming a global entry point into
+your application's internal request logic.
 
-So while signing removes the forging vector, app-isolation and per-view scoping
-remain the layer that keeps a registered handler from becoming a global entry
-point into your application’s internal request logic.
 
-Design Goals
-~~~~~~~~~~~~
+The Controls: App Isolation and Scoping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The new HxRequest security layer enforces:
+The security layer is built around four goals:
 
-1. **App Isolation** – Prevent cross-app access by default (i.e 3rd party untrusted packages).
+1. **App Isolation** – Prevent cross-app access by default (i.e. 3rd-party untrusted packages).
 2. **Explicit Trust** – Cross-app usage must be declared via settings or per-view rules.
 3. **Safe Extensibility** – Shared internal libraries can safely opt in to wider access via settings.
 4. **Predictability** – Even if enforcement is disabled, the logic runs consistently.
 
-
-What Happens Without Controls
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you remove these checks, anyone holding a valid token for an
-:code:`HxRequest` (one rendered on any page they can reach) can:
-
-    - Replay that request against unrelated views.
-    - Modify or delete data outside its intended scope.
-    - Execute sensitive operations from unprotected endpoints.
-
-
-Security Model Overview
-~~~~~~~~~~~~~~~~~~~~~~~
+They are enforced through four layers:
 
 ============================  ============================================
 **Layer**                     **Responsibility**
@@ -102,12 +85,38 @@ Per-View Controls             Adds fine-grained access (allowed HxRequests)
 Additive Logic                Combines or replaces base rule
 ============================  ============================================
 
+See :ref:`How To Secure HxRequests <how-to-secure-hxrequests>` for configuration
+examples of each layer.
+
+
+Path-Binding
+~~~~~~~~~~~~
+
+The controls above answer *which handlers a given view may run*. On top of them,
+every signed token is, by default, **bound to the URL path it was rendered on**:
+the token records the server-side :code:`request.path` at mint time (never the
+client-supplied :code:`HX-Current-URL` header), and it verifies only when
+replayed back to that same path. The
+:code:`/home/?hx=<a-real-token-for-delete_all_records_hx>` replay above therefore
+fails and returns :code:`Http404` before the request is routed.
+
+This narrows *where* a token can be used; it is **not** an authorization check. A
+user who can load the page a token was minted on still holds a token valid for
+that path — so the scoping controls (and any auth on the originating view) remain
+the layer that decides *who* may run the handler.
+
+Path-binding is automatic. For the rare case where a token must work across paths
+(e.g. a proxy that rewrites :code:`request.path`), a handler can opt out with
+:code:`bind_to_path = False`, or the whole project can disable it with
+:code:`HX_REQUESTS_BIND_TOKEN_TO_PATH = False` — see
+:ref:`How To Secure HxRequests <how-to-secure-hxrequests>`.
+
 
 When To Relax Controls
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 You should loosen restrictions only when you **trust the source** of the request
-and the operation is something that **any user could safely perform**—
+and the operation is something that **any user could safely perform** —
 for example, when triggering a non-sensitive UI component or an action that does
 not expose or modify private data.
 
@@ -121,17 +130,19 @@ Typical valid cases include:
 
     Do not disable app enforcement globally or allow untrusted apps.
     Doing so allows external or third-party code to trigger
-    **any HxRequest** in your project. code to trigger
     **any HxRequest** in your project.
 
 
 Summary
 ~~~~~~~
 
-Signing ensures a request's name, object, and kwargs can't be forged. On top of
-that, the controls here ensure a registered handler doesn't become a remote-call
-interface to your entire Django project by respecting application boundaries and
-explicit trust.
+- **Signing** ensures a request's name, object, and kwargs can't be forged.
+- **App-isolation and scoping** ensure a registered handler doesn't become a
+  remote-call interface to your whole project, by respecting application
+  boundaries and explicit trust.
+- **Path-binding** binds each token to the page it was rendered on by default, so
+  a token can't be replayed against a different view's path; opt out per handler
+  with :code:`bind_to_path = False`.
 
 Continue to :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 for configuration examples.

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -12,24 +12,54 @@ and when it is safe to relax it.
 
 .. note::
 
-    **Request signing comes first.** The :code:`HxRequest` name, object, and
-    kwargs are delivered in a single HMAC-signed :code:`hx` token, so a client
-    **cannot forge or hand-craft** a request for an arbitrary handler — a
-    missing or tampered token is rejected with :code:`Http404` before any
-    routing happens. Everything on this page is the *next* layer: it governs a
-    token that was issued legitimately somewhere and then replayed against a
-    view that shouldn't accept it.
+    **Request signing comes first** (see :ref:`Request Signing`): a client
+    **cannot forge or tamper with** a request's routing data. The layers after it
+    govern a *legitimately-issued* token — used from a page, or by a user, it
+    shouldn't be.
 
 See also: :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
+
+
+Request Signing
+~~~~~~~~~~~~~~~
+
+The routing data an :code:`HxRequest` runs on — the handler **name**, the
+**object** it acts on, and any **kwargs** — travels in a single HMAC-signed
+:code:`hx` token instead of as loose, client-editable query parameters. The
+token is produced with :code:`django.core.signing` and your project's
+:code:`SECRET_KEY`: a client can read it (it is base64-encoded JSON) but cannot
+alter or fabricate one, because any change invalidates the signature.
+:code:`HtmxViewMixin` rebuilds the request from the *verified* payload only, and
+returns :code:`Http404` on a missing, tampered, or hand-crafted token before any
+deserializer or handler runs.
+
+**What signing protects.** When the name, object, and kwargs were loose query
+parameters, a client could edit them on the URL. Signing closes those tampering
+vectors:
+
+    - **Object tampering / IDOR** — a client can't change the serialized
+      :code:`object` (e.g. swap a primary key) to make a handler act on a record
+      that isn't theirs.
+    - **Cross-model instance swap** — the serialized object can't be repointed at
+      a different model.
+    - **Context / kwarg forgery** — a client can't inject kwargs (e.g. a
+      :code:`___can_edit` flag) to force values into the handler's context.
+    - **Handler spoofing** — a client can't hand-craft a token that routes to an
+      arbitrary handler name.
+    - **Garbage-input 500s** — malformed routing data fails the signature check
+      and 404s, instead of reaching a deserializer and raising.
+
+**What signing does not decide.** A signature proves a token was issued by your
+server and hasn't been altered. It does **not** decide *who* may use a token or
+*where*: a legitimately-issued token can still be replayed by another user or
+from another page. Path-binding and the scoping controls below are those layers.
 
 
 The Threat: Replaying a Valid Token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Signing stops a client from *hand-crafting* a request for an arbitrary handler
-— a URL like :code:`/home/?hx=<made-up-token>` is rejected because the token
-won't verify. What signing does **not** decide is *scope*: which registered
-handlers a given view is willing to run.
+Signing proves a token is genuine, but it doesn't decide *scope*: which
+registered handlers a given view is willing to run.
 
 Because :code:`HtmxViewMixin` routes any HTMX request by the (verified) name
 inside the token, **any view that includes the mixin** is a potential entry
@@ -49,7 +79,19 @@ signature alone stops them from replaying it against an unrelated view:
 
 If :code:`/home` is a simple, public-facing view that includes the
 :code:`HtmxViewMixin` and neither scopes its handlers nor enforces auth, this
-request would still reach and execute the deletion logic. The consequences:
+request would still reach and execute the deletion logic.
+
+.. note::
+
+    By default this exact cross-page replay is **already blocked**: tokens are
+    :ref:`path-bound <path-binding>`, so a token minted on the admin page is
+    rejected on :code:`/home`. The scenario here is what happens *without* that
+    layer — or when it is relaxed. App-isolation and scoping remain necessary for
+    the case path-binding can't cover: a handler minted from a view or app that
+    should never render it (e.g. a third-party template), where the token is
+    bound to *that* page and posting it back there succeeds.
+
+The consequences:
 
     - The route doesn't matter — any view using the mixin is a potential gateway
       for any registered :code:`HxRequest` it doesn't scope.
@@ -88,6 +130,8 @@ Additive Logic                Combines or replaces base rule
 See :ref:`How To Secure HxRequests <how-to-secure-hxrequests>` for configuration
 examples of each layer.
 
+
+.. _path-binding:
 
 Path-Binding
 ~~~~~~~~~~~~

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -50,9 +50,13 @@ vectors:
       and 404s, instead of reaching a deserializer and raising.
 
 **What signing does not decide.** A signature proves a token was issued by your
-server and hasn't been altered. It does **not** decide *who* may use a token or
-*where*: a legitimately-issued token can still be replayed by another user or
-from another page. Path-binding and the scoping controls below are those layers.
+server and hasn't been altered — not *where* it may be used or *who* may use it.
+A legitimately-issued token can still be sent from another page, or by another
+user. *Where* is constrained by path-binding (below). *Who* is **not** answered
+by the scoping controls here — it comes from requiring authentication
+(:code:`HX_REQUESTS_REQUIRE_AUTH`) and the permissions on the view a request
+routes through. The scoping controls below are a third axis: which handlers a
+given view or app may run at all.
 
 
 The Threat: Replaying a Valid Token

--- a/docs/how_tos/detect_hx_request.rst
+++ b/docs/how_tos/detect_hx_request.rst
@@ -1,0 +1,66 @@
+How To Detect And Inspect An HxRequest
+--------------------------------------
+
+The routing data (name, object, kwargs) is signed inside a single :code:`hx`
+token, so it is no longer readable as loose :code:`hx_request_name` /
+:code:`object` / :code:`___kwarg` query parameters. To work with an inbound
+request from your own view code, use the helpers in :code:`hx_requests.utils`.
+
+Checking If A Request Is An HxRequest
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:code:`is_hx_request(request)` returns :code:`True` when the request carries a
+valid signed token — i.e. it is bound for a registered :code:`HxRequest`.
+
+This is different from :code:`is_htmx_request(request)`, which only checks the
+:code:`HX-Request` header and is :code:`True` for *any* htmx request. The common
+use is telling a plain htmx request (sort / filter / paginate) apart from one
+routed to an :code:`HxRequest`, so the plain one can fall through to the
+underlying view:
+
+.. code-block:: python
+
+    from hx_requests.utils import is_htmx_request, is_hx_request
+
+    def dispatch(self, request, *args, **kwargs):
+        # Plain htmx (no hx token) -> let the underlying view handle it.
+        if is_htmx_request(request) and not is_hx_request(request):
+            return SomeListView.dispatch(self, request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
+
+Reading The Name, Object, And Kwargs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you need the request's data before dispatch runs:
+
+- :code:`get_hx_request_name(request)` returns the verified name (or :code:`None`).
+- :code:`get_hx_payload(request)` returns the full verified payload,
+  :code:`{"name": ..., "object": ..., "kwargs": ...}` (or :code:`None`).
+
+.. code-block:: python
+
+    from hx_requests.utils import get_hx_request_name, get_hx_payload
+
+    name = get_hx_request_name(request)
+
+    payload = get_hx_payload(request)
+    if payload:
+        name = payload["name"]
+
+The :code:`object` and :code:`kwargs` in the payload are still in serialized
+form. Run them through :code:`deserialize` / :code:`deserialize_kwargs` to get
+live values:
+
+.. code-block:: python
+
+    from hx_requests.utils import get_hx_payload, deserialize, deserialize_kwargs
+
+    payload = get_hx_payload(request)
+    if payload:
+        obj = deserialize(payload["object"]) if payload["object"] else None
+        kwargs = deserialize_kwargs(**payload["kwargs"])
+
+.. note::
+
+    All of these helpers return :code:`None` / :code:`False` on a missing or
+    tampered token — they never raise — so they are safe to call on any request.

--- a/docs/how_tos/index.rst
+++ b/docs/how_tos/index.rst
@@ -5,6 +5,7 @@ How Tos
    :maxdepth: 1
 
    register_hx_requests
+   detect_hx_request
    secure_hx_requests
    use_modals
    oob_swap

--- a/docs/how_tos/secure_hx_requests.rst
+++ b/docs/how_tos/secure_hx_requests.rst
@@ -176,8 +176,8 @@ Only HxRequests in :code:`allowed_hx_requests` can be called from this view
 
 
 
-Path-Binding
-~~~~~~~~~~~~
+Relaxing Path-Binding
+~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, every signed token is bound to the URL path it was rendered on, so it
 only verifies when replayed back to that same path (see

--- a/docs/how_tos/secure_hx_requests.rst
+++ b/docs/how_tos/secure_hx_requests.rst
@@ -2,8 +2,10 @@ How To Secure HxRequests
 ------------------------
 
 HxRequests allow modular, component-level interactions between the frontend and backend.
-However, without proper access controls, any request can be triggered from any page
-by including the :code:`hx_request_name` parameter in the URL.
+Request signing already stops a client from forging a request for an arbitrary
+handler, but without per-view access controls a validly-issued request can still
+be replayed against any view that includes the mixin and doesn't scope which
+handlers it accepts.
 
 This guide explains **how to secure HxRequests**, enforce app boundaries,
 require authentication when appropriate, and explicitly allow cross-app usage where needed.

--- a/docs/how_tos/secure_hx_requests.rst
+++ b/docs/how_tos/secure_hx_requests.rst
@@ -176,6 +176,54 @@ Only HxRequests in :code:`allowed_hx_requests` can be called from this view
 
 
 
+Path-Binding
+~~~~~~~~~~~~
+
+By default, every signed token is bound to the URL path it was rendered on, so it
+only verifies when replayed back to that same path (see
+:ref:`Why HxRequest Security Is Needed <why-hxrequest-security>`). This is
+automatic — there is nothing to enable.
+
+You only need to relax it when the path Django sees at dispatch can legitimately
+differ from the path a token was rendered on. That comes up in two shapes.
+
+
+Disabling Globally
+^^^^^^^^^^^^^^^^^^
+
+If your whole project sits behind a proxy or middleware that rewrites or strips
+part of the path (a locale prefix, a mount sub-path / :code:`SCRIPT_NAME`)
+between the browser and Django, the rendered path and the dispatched path won't
+match. Turn path-binding off project-wide:
+
+.. code-block:: python
+
+    # settings.py
+    HX_REQUESTS_BIND_TOKEN_TO_PATH = False
+
+This disables both minting new bound tokens **and** enforcing existing ones, so
+it takes effect immediately — already-rendered pages stop failing without a
+reload.
+
+
+Opting Out Per Handler
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a single handler whose token must work from a path other than where it was
+rendered — e.g. you build the request URL yourself, or reuse one token across
+several URLs instead of letting the tags emit it — opt that handler out:
+
+.. code-block:: python
+
+    class CrossPageHx(BaseHxRequest):
+        name = "cross_page"
+        bind_to_path = False
+
+In ordinary usage you never hit either case: the template tags bake the render
+path into the request URL, so the token is always posted back to the path it was
+bound to.
+
+
 Evaluation Order
 ~~~~~~~~~~~~~~~~
 
@@ -207,6 +255,8 @@ Summary
 :code:`HX_REQUESTS_GLOBAL_ALLOW`         Define trusted apps or HxRequests globally
 :code:`allowed_hx_requests`              Per-view allowed HxRequests
 :code:`use_global_hx_rules`              Whether per-view list builds upon the global list or restricts it further
+:code:`HX_REQUESTS_BIND_TOKEN_TO_PATH`   Default: bind each token to its render path (set False to disable project-wide)
+:code:`bind_to_path`                     Per-handler opt-out of path-binding
 =======================================  ===========================================
 
 .. warning::

--- a/docs/reference/hx_tags.rst
+++ b/docs/reference/hx_tags.rst
@@ -21,7 +21,7 @@ Behavior
     - Kwargs
         - Accessible in the :code:`HxRequest` through :code:`**kwargs` in each method.
         - Available in the template as context variables, unless :code:`kwargs_as_context = False` is set on the :code:`HxRequest`, in which case they are stored in :code:`hx_kwargs`, accessible as {{ hx_kwargs.key }}.
-        - :code:`kwargs` are prefixed with :code:`___` to differentiate them from standard query parameters (see :ref:`Handling kwargs Serialization`).
+        - :code:`kwargs` are serialized (see :ref:`Handling kwargs Serialization`) and carried inside the signed token, not as loose query parameters.
 
 Example
 ~~~~~~~
@@ -35,9 +35,15 @@ Is equal to:
 
 .. code-block:: html+django
 
-    <button hx-get="my-website/current-page?hx_request_name=my_hx_request&object=model_instance__app_name__model__id_of_my_instance"></button>
+    <button hx-get="my-website/current-page?hx=<signed-token>"></button>
+
+The :code:`hx` parameter is a single HMAC-signed token that packs the
+:code:`HxRequest` name, the serialized object, and any serialized kwargs. The
+client can read the token but cannot forge or tamper with it without the
+project's :code:`SECRET_KEY`, so the name/object/kwargs are trusted framework
+data rather than editable query params.
 
 .. note::
 
-    See :ref:`Object Serialization` for more information on how objects are serialized.
-`
+    See :ref:`Object Serialization` for more information on how objects and
+    kwargs are serialized and packed into the token.

--- a/hx_requests/constants.py
+++ b/hx_requests/constants.py
@@ -1,0 +1,10 @@
+MODEL_INSTANCE_PREFIX = "model_instance__"
+KWARG_PREFIX = "___"
+
+# Query param that carries the signed round-trip token, and the signing salt.
+# The salt only namespaces the signature; secrecy comes from SECRET_KEY. A
+# per-name salt is intentionally NOT used: the handler name lives inside the
+# signed payload, so a token minted for one handler cannot be replayed against
+# another (tampering the name invalidates the signature).
+HX_TOKEN_PARAM = "hx"
+HX_SIGNING_SALT = "hx-requests"

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -76,6 +76,12 @@ class BaseHxRequest:
         If True, the request adds the GET params from the current browser URL to the request.
         The GET params submitted with the request (I.e via hx-vals) override the ones in the
         current URL.
+    bind_to_path: bool (default True)
+        The signed token is bound to the URL path it was rendered on, so it only
+        verifies when replayed back to that same path. On by default; set to False
+        for a handler whose token must work across paths. Origin hardening layered on
+        top of authorization -- it narrows the "replay from another page" surface, it
+        does not replace an authorization check.
 
 
 
@@ -99,6 +105,7 @@ class BaseHxRequest:
     kwargs_as_context: bool = True
     refresh_views_context_on_POST: bool = False
     use_current_url: bool = False
+    bind_to_path: bool = True
 
     #: Maps the friendly phase keys accepted in a dict return from
     #: :meth:`get_triggers` to their HTMX response-header names.

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -1,12 +1,18 @@
 import json
-from urllib.parse import quote_plus, urlencode, urlparse
+from urllib.parse import urlencode
 
 from django.apps import apps
+from django.core import signing
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
-MODEL_INSTANCE_PREFIX = "model_instance__"
-KWARG_PREFIX = "___"
+from hx_requests.constants import (
+    HX_SIGNING_SALT,
+    HX_TOKEN_PARAM,
+    KWARG_PREFIX,
+    MODEL_INSTANCE_PREFIX,
+)
+
 __ = "__"
 
 
@@ -50,35 +56,94 @@ def deserialize_kwargs(**kwargs):
     return deserialized_kwargs
 
 
+def sign_hx_payload(hx_request_name, obj=None, **kwargs):
+    """
+    Pack everything the template tag controls -- the handler name, the object,
+    and the extra kwargs -- into a single HMAC-signed token. The client can
+    read the token (it is base64-encoded JSON) but cannot forge it without
+    ``SECRET_KEY``, which closes the object/kwarg/name tampering vectors.
+    """
+    payload = {
+        "name": hx_request_name,
+        "object": serialize(obj) if obj is not None else None,
+        "kwargs": serialize_kwargs(**kwargs),
+    }
+    return signing.dumps(payload, salt=HX_SIGNING_SALT)
+
+
+def unsign_hx_payload(token):
+    """
+    Verify and unpack a signed token. Raises ``signing.BadSignature`` (a base
+    class covering tampered/truncated/hand-crafted tokens) on any failure.
+    """
+    return signing.loads(token, salt=HX_SIGNING_SALT)
+
+
+def get_hx_payload(request):
+    """
+    Return the *verified* contents of the signed ``hx`` token on ``request`` as
+    ``{"name": ..., "object": ..., "kwargs": ...}``, or ``None`` if the request
+    carries no token or the signature is invalid.
+
+    This is the supported way for view code to introspect an inbound
+    hx-requests request (detect it, read its name/object/kwargs) *without*
+    going through ``HtmxViewMixin`` dispatch. The ``object`` and ``kwargs``
+    values are still in serialized form -- pass them through :func:`deserialize`
+    / :func:`deserialize_kwargs` to get live values.
+    """
+    token = request.GET.get(HX_TOKEN_PARAM)
+    if not token:
+        return None
+    try:
+        return unsign_hx_payload(token)
+    except signing.BadSignature:
+        return None
+
+
+def get_hx_request_name(request):
+    """
+    Return the :code:`HxRequest` name from the signed ``hx`` token, or ``None``
+    if the request isn't a (valid) hx-requests request.
+
+    Replaces reading ``request.GET["hx_request_name"]`` directly, which no
+    longer exists on the query string now that routing data is signed.
+    """
+    payload = get_hx_payload(request)
+    return payload["name"] if payload else None
+
+
+def is_hx_request(request):
+    """
+    Return ``True`` if ``request`` is an hx-requests request -- i.e. it carries
+    a valid signed ``hx`` token bound for a registered handler.
+
+    This is distinct from :func:`is_htmx_request`, which only checks the
+    ``HX-Request`` header (*any* htmx request). Use it to tell a plain htmx
+    request (sort / filter / paginate) apart from one routed to an
+    :code:`HxRequest`::
+
+        if is_htmx_request(request) and not is_hx_request(request):
+            ...  # plain htmx -- let the underlying view handle it
+    """
+    return get_hx_payload(request) is not None
+
+
 def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
     request = context["request"]
-    url = request.path
 
-    params = {"hx_request_name": hx_request_name}
-
+    # Non-framework params (page filters/pagination) stay as ordinary loose
+    # query params -- they are untrusted runtime input the view already reads.
+    # Only the framework's routing/deserialization data is signed.
+    params = {}
     if use_full_path:
-        get_params = {}
         for k, v in request.GET.lists():
-            if k not in ["hx_request_name", "object"] and not k.startswith(KWARG_PREFIX):
-                get_params[k] = v[0] if len(v) == 1 else v
-        params.update(get_params)
+            if k in (HX_TOKEN_PARAM, "hx_request_name", "object") or k.startswith(KWARG_PREFIX):
+                continue
+            params[k] = v[0] if len(v) == 1 else v
 
-    if obj:
-        params["object"] = serialize(obj)
+    params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, **kwargs)
 
-    # Parse the URL to check if there are existing query parameters
-    parsed_url = urlparse(url)
-    if parsed_url.query:  # If there are existing query parameters
-        url += "&"  # Append using "&"
-    else:
-        url += "?"  # Otherwise, start with "?"
-
-    url += urlencode(params, doseq=True)
-
-    serialized_kwargs = serialize_kwargs(**kwargs)
-    url += "".join(f"&{k}={quote_plus(str(v))}" for k, v in serialized_kwargs.items())
-
-    return url
+    return f"{request.path}?{urlencode(params, doseq=True)}"
 
 
 def get_csrf_token(context):

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -56,18 +56,23 @@ def deserialize_kwargs(**kwargs):
     return deserialized_kwargs
 
 
-def sign_hx_payload(hx_request_name, obj=None, **kwargs):
+def sign_hx_payload(hx_request_name, obj=None, bind_path=None, **kwargs):
     """
     Pack everything the template tag controls -- the handler name, the object,
     and the extra kwargs -- into a single HMAC-signed token. The client can
     read the token (it is base64-encoded JSON) but cannot forge it without
     ``SECRET_KEY``, which closes the object/kwarg/name tampering vectors.
+
+    When ``bind_path`` is given, it is packed into the token too, binding the
+    token to that URL path (see :func:`get_url` and ``bind_to_path``).
     """
     payload = {
         "name": hx_request_name,
         "object": serialize(obj) if obj is not None else None,
         "kwargs": serialize_kwargs(**kwargs),
     }
+    if bind_path is not None:
+        payload["path"] = bind_path
     return signing.dumps(payload, salt=HX_SIGNING_SALT)
 
 
@@ -141,9 +146,27 @@ def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
                 continue
             params[k] = v[0] if len(v) == 1 else v
 
-    params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, **kwargs)
+    # The token is bound to the path it is rendered on (so it only verifies when
+    # replayed back to this same path) unless the handler opts out.
+    bind_path = request.path if _handler_binds_to_path(hx_request_name) else None
+    params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, bind_path=bind_path, **kwargs)
 
     return f"{request.path}?{urlencode(params, doseq=True)}"
+
+
+def _handler_binds_to_path(hx_request_name):
+    from django.conf import settings
+
+    # Global kill switch (e.g. when a proxy/middleware rewrites request.path).
+    if not getattr(settings, "HX_REQUESTS_BIND_TOKEN_TO_PATH", True):
+        return False
+
+    # Lazy import: avoids a utils <-> hx_registry <-> hx_requests import cycle.
+    from hx_requests.hx_registry import HxRequestRegistry
+
+    hx_request_class = HxRequestRegistry.get_hx_request(hx_request_name)
+    # Path-binding is on by default; a handler opts out with bind_to_path = False.
+    return bool(getattr(hx_request_class, "bind_to_path", True))
 
 
 def get_csrf_token(context):

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlencode
 
 from django.apps import apps
+from django.conf import settings
 from django.core import signing
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -155,8 +156,6 @@ def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
 
 
 def _handler_binds_to_path(hx_request_name):
-    from django.conf import settings
-
     # Global kill switch (e.g. when a proxy/middleware rewrites request.path).
     if not getattr(settings, "HX_REQUESTS_BIND_TOKEN_TO_PATH", True):
         return False

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -7,13 +7,18 @@ from django.http import Http404, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 
+from hx_requests.constants import HX_TOKEN_PARAM, KWARG_PREFIX
 from hx_requests.hx_registry import HxRequestRegistry
 from hx_requests.security_utils import (
     app_label_for_object,
     is_globally_allowed,
     is_unauthenticated_allowed,
 )
-from hx_requests.utils import deserialize_kwargs, is_htmx_request
+from hx_requests.utils import (
+    deserialize_kwargs,
+    get_hx_payload,
+    is_htmx_request,
+)
 
 
 @method_decorator(ensure_csrf_cookie, name="dispatch")
@@ -35,6 +40,7 @@ class HtmxViewMixin:
             # If it's an HTMX request, hand off to the resolved HxRequest's
             # own dispatch; otherwise, let the view class handle the request.
             if is_htmx_request(request):
+                request = self._resolve_hx_token(request)
                 kwargs.update(self.get_hx_extra_kwargs(request))
                 hx_request = self._setup_hx_request(request, *args, **kwargs)
 
@@ -59,13 +65,37 @@ class HtmxViewMixin:
 
         return hx_request_class()
 
+    def _resolve_hx_token(self, request):
+        """
+        Verify the signed ``hx`` token and rebuild ``request.GET`` so the rest
+        of the chain reads *trusted* framework data. Everything the framework
+        controls (name, object, kwargs) comes from the signed token; any
+        client-supplied framework params on the raw query string are dropped so
+        they cannot shadow or forge the verified values. Non-framework params
+        (page filters, runtime hx-vals) are left untouched.
+        """
+        if not request.GET.get(HX_TOKEN_PARAM):
+            raise Http404("Missing required query param 'hx' for HTMX request.")
+        payload = get_hx_payload(request)
+        if payload is None:
+            raise Http404("Invalid or tampered hx token.")
+
+        sanitized = request.GET.copy()
+        for key in list(sanitized.keys()):
+            if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+                del sanitized[key]
+        sanitized["hx_request_name"] = payload["name"]
+        if payload.get("object"):
+            sanitized["object"] = payload["object"]
+
+        request.GET = sanitized
+        # Verified, serialized kwargs from the token -- the only source of
+        # kwargs-as-context. Raw query params never feed this again.
+        request._hx_kwargs = payload.get("kwargs", {})
+        return request
+
     def get_hx_extra_kwargs(self, request):
-        raw = {}
-        for key in request.GET:
-            if key == "hx_request_name":
-                continue
-            raw[key] = request.GET.get(key)
-        return deserialize_kwargs(**raw)
+        return deserialize_kwargs(**getattr(request, "_hx_kwargs", {}))
 
     def _setup_hx_request(self, request, *args, **kwargs):
         hx_request = self.get_hx_request(request)
@@ -137,8 +167,12 @@ class HtmxViewMixin:
             parsed_url = urlparse(hx_current_url)
             additional_params = parse_qs(parsed_url.query)
 
-            # Add each HX param only if not already present
+            # Add each HX param only if not already present. Framework params
+            # (name/object/kwargs/token) are never merged from the current URL:
+            # those are trusted only via the signed token, not raw query input.
             for key, values in additional_params.items():
+                if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+                    continue
                 if key not in merged_get:
                     merged_get.setlist(key, values)
 

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -80,6 +80,15 @@ class HtmxViewMixin:
         if payload is None:
             raise Http404("Invalid or tampered hx token.")
 
+        # A path-bound token (bind_to_path handler) only verifies on the path it
+        # was minted for -- replaying it against another view's path is rejected.
+        # The global HX_REQUESTS_BIND_TOKEN_TO_PATH switch disables the check so
+        # already-minted bound tokens stop 404ing the moment it is turned off.
+        bound_path = payload.get("path")
+        binding_enabled = getattr(settings, "HX_REQUESTS_BIND_TOKEN_TO_PATH", True)
+        if binding_enabled and bound_path is not None and bound_path != request.path:
+            raise Http404("hx token is bound to a different path.")
+
         sanitized = request.GET.copy()
         for key in list(sanitized.keys()):
             if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory
 from django.views import View
 
-from hx_requests.utils import serialize, serialize_kwargs
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
 
 
 def add_middleware_to_request(request):
@@ -46,14 +46,12 @@ def _create_test_request(
             request.user = AnonymousUser()
         return request
 
-    # Used even on POST to set kwargs to GET params
+    # The framework's routing data (name, object, kwargs) rides in one signed
+    # token, exactly as the template tags emit it; get_params stay loose.
     hx_object = hx_kwargs.pop("object", None)
-    hx_kwargs = serialize_kwargs(**hx_kwargs)
-    if hx_object is not None:
-        hx_kwargs["object"] = serialize(hx_object)
-    hx_kwargs["hx_request_name"] = hx_request.name
-    hx_kwargs.update(get_params)
-    request = RequestFactory().get("/", data=hx_kwargs)
+    query = {HX_TOKEN_PARAM: sign_hx_payload(hx_request.name, hx_object, **hx_kwargs)}
+    query.update(get_params)
+    request = RequestFactory().get("/", data=query)
 
     if method == "POST":
         request = RequestFactory().post(f"/?{request.META['QUERY_STRING']}", data=post_data or {})

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -29,6 +29,13 @@ class SimpleGetHx(BaseHxRequest):
     GET_template = "simple.html"
 
 
+class UnboundHx(BaseHxRequest):
+    # Opts out of the default path-binding.
+    name = "unbound"
+    GET_template = "simple.html"
+    bind_to_path = False
+
+
 class ViewTemplateFallbackHx(BaseHxRequest):
     name = "view_template_fallback"
 

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -1,6 +1,7 @@
 """Integration tests for BaseHxRequest driven through HtmxViewMixin."""
 
 import json
+from urllib.parse import urlencode
 
 import pytest
 from django.http import Http404
@@ -9,6 +10,7 @@ from test_app import hx_requests as hx
 from test_app.models import Widget
 from test_app.views import BaseView, WidgetContextView, WidgetListView, WidgetUpdateView
 
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
 from tests.helpers import add_middleware_to_request, hx_get, hx_post
 
 pytestmark = pytest.mark.django_db
@@ -315,7 +317,8 @@ def test_messages_disabled_globally():
 
 
 def test_unsupported_method_returns_405():
-    request = RequestFactory().patch("/?hx_request_name=simple_get")
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().patch(f"/?{urlencode({HX_TOKEN_PARAM: token})}")
     request.META["HTTP_HX_REQUEST"] = True
     add_middleware_to_request(request)
     response = BaseView.as_view()(request)
@@ -336,7 +339,7 @@ def test_non_htmx_request_falls_through_to_the_view():
     assert "view_flavor:from-the-view" in content_of(response)
 
 
-def test_missing_hx_request_name_raises_404():
+def test_missing_hx_token_raises_404():
     request = RequestFactory().get("/")
     request.META["HTTP_HX_REQUEST"] = True
     add_middleware_to_request(request)
@@ -344,8 +347,17 @@ def test_missing_hx_request_name_raises_404():
         BaseView.as_view()(request)
 
 
+def test_tampered_hx_token_raises_404():
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token[:-3] + "xxx"})
+    request.META["HTTP_HX_REQUEST"] = True
+    add_middleware_to_request(request)
+    with pytest.raises(Http404, match="Invalid or tampered"):
+        BaseView.as_view()(request)
+
+
 def test_unknown_hx_request_name_raises_404():
-    request = RequestFactory().get("/", data={"hx_request_name": "does_not_exist"})
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: sign_hx_payload("does_not_exist")})
     request.META["HTTP_HX_REQUEST"] = True
     add_middleware_to_request(request)
     with pytest.raises(Http404, match="No HxRequest found"):

--- a/tests/test_hx_tags.py
+++ b/tests/test_hx_tags.py
@@ -1,32 +1,46 @@
 """Tests for the hx_tags template tags."""
 
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 from django.template import Context, Template
 from django.test import RequestFactory
 
 from hx_requests.templatetags.hx_tags import hx_get, hx_post, hx_url
+from hx_requests.utils import HX_TOKEN_PARAM, deserialize, deserialize_kwargs, unsign_hx_payload
 
 
 def make_context(path="/page/", **extra):
     return {"request": RequestFactory().get(path, **extra)}
 
 
+def payload_from_attr(attr):
+    # attr looks like `hx-get=/page/?hx=<token>` (optionally with more attrs).
+    url = attr.split("=", 1)[1].split(" ", 1)[0]
+    query = parse_qs(urlparse(url).query)
+    return unsign_hx_payload(query[HX_TOKEN_PARAM][0])
+
+
 def test_hx_get_renders_attribute():
-    assert hx_get(make_context(), "simple_get") == "hx-get=/page/?hx_request_name=simple_get"
+    out = hx_get(make_context(), "simple_get")
+    assert out.startswith("hx-get=/page/?")
+    assert payload_from_attr(out)["name"] == "simple_get"
 
 
 @pytest.mark.django_db()
 def test_hx_get_includes_object_and_kwargs(widget):
     out = hx_get(make_context(), "simple_get", object=widget, flavor="spicy")
-    assert out.startswith("hx-get=/page/?hx_request_name=simple_get")
-    assert f"object=model_instance__test_app__widget__{widget.pk}" in out
-    assert "___flavor=%22spicy%22" in out
+    payload = payload_from_attr(out)
+    assert payload["name"] == "simple_get"
+    assert deserialize(payload["object"]) == widget
+    assert deserialize_kwargs(**payload["kwargs"]) == {"flavor": "spicy"}
 
 
 def test_hx_post_includes_csrf_headers_from_cookie():
     context = make_context(HTTP_COOKIE="csrftoken=tok123")
     out = hx_post(context, "simple_get")
-    assert out.startswith("hx-post=/page/?hx_request_name=simple_get")
+    assert out.startswith("hx-post=/page/?")
+    assert payload_from_attr(out)["name"] == "simple_get"
     assert 'hx-headers={"X-CSRFTOKEN":"tok123"}' in out
 
 
@@ -36,10 +50,15 @@ def test_hx_post_without_csrf_cookie_omits_headers():
 
 
 def test_hx_url_returns_bare_url():
-    assert hx_url(make_context(), "simple_get") == "/page/?hx_request_name=simple_get"
+    out = hx_url(make_context(), "simple_get")
+    assert out.startswith("/page/?")
+    query = parse_qs(urlparse(out).query)
+    assert unsign_hx_payload(query[HX_TOKEN_PARAM][0])["name"] == "simple_get"
 
 
 def test_tags_render_through_the_template_engine():
     template = Template("{% load hx_tags %}{% hx_url 'simple_get' %}")
     rendered = template.render(Context(make_context()))
-    assert rendered == "/page/?hx_request_name=simple_get"
+    assert rendered.startswith("/page/?")
+    query = parse_qs(urlparse(rendered).query)
+    assert unsign_hx_payload(query[HX_TOKEN_PARAM][0])["name"] == "simple_get"

--- a/tests/test_path_binding.py
+++ b/tests/test_path_binding.py
@@ -1,0 +1,83 @@
+"""Security tests for optional path-binding of the signed hx token.
+
+A handler may set ``bind_to_path = True`` to have its token bound to the URL
+path it was rendered on. Such a token verifies only when it is replayed back to
+that same path, which narrows the "replay from another page" surface. This is
+origin hardening layered on top of authorization -- not a replacement for it.
+"""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.core import signing
+from django.http import Http404
+from django.test import RequestFactory, override_settings
+from test_app.views import BaseView
+
+from hx_requests.templatetags.hx_tags import hx_url
+from hx_requests.utils import HX_SIGNING_SALT, HX_TOKEN_PARAM, unsign_hx_payload
+from tests.helpers import add_middleware_to_request
+
+pytestmark = pytest.mark.django_db
+
+
+def _payload_from_url(url):
+    query = parse_qs(urlparse(url).query)
+    return unsign_hx_payload(query[HX_TOKEN_PARAM][0])
+
+
+def _bound_request(path, bound_to):
+    # A validly-signed token whose payload is bound to ``bound_to``, arriving at
+    # ``path``. Built by hand so the wire format is explicit and the test does
+    # not depend on the mint side.
+    token = signing.dumps(
+        {"name": "simple_get", "object": None, "kwargs": {}, "path": bound_to},
+        salt=HX_SIGNING_SALT,
+    )
+    request = RequestFactory().get(path, data={HX_TOKEN_PARAM: token})
+    request.META["HTTP_HX_REQUEST"] = True
+    add_middleware_to_request(request)
+    return request
+
+
+def test_tokens_are_path_bound_by_default():
+    # Path-binding is on by default: an ordinary handler binds its render path.
+    out = hx_url({"request": RequestFactory().get("/page/")}, "simple_get")
+    assert _payload_from_url(out).get("path") == "/page/"
+
+
+def test_opted_out_handler_has_no_path():
+    # A handler with bind_to_path = False mints an unbound token.
+    out = hx_url({"request": RequestFactory().get("/page/")}, "unbound")
+    assert "path" not in _payload_from_url(out)
+
+
+def test_replaying_bound_token_to_a_different_path_is_rejected():
+    # The exact vector path-binding closes: a real token minted on /page/ is
+    # replayed against /other/. It must be rejected before dispatch.
+    request = _bound_request(path="/other/", bound_to="/page/")
+    with pytest.raises(Http404):
+        BaseView()._resolve_hx_token(request)
+
+
+def test_bound_token_on_its_own_path_is_accepted():
+    # The legitimate case: the token is used on the path it was bound to.
+    request = _bound_request(path="/page/", bound_to="/page/")
+    BaseView()._resolve_hx_token(request)
+    assert request.GET["hx_request_name"] == "simple_get"
+
+
+@override_settings(HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
+def test_global_setting_disables_binding_at_mint():
+    # The global kill switch stops new tokens from being path-bound at all.
+    out = hx_url({"request": RequestFactory().get("/page/")}, "simple_get")
+    assert "path" not in _payload_from_url(out)
+
+
+@override_settings(HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
+def test_global_setting_disables_enforcement():
+    # It also stops enforcement, so already-minted bound tokens stop 404ing
+    # immediately (e.g. after enabling it to work around path rewriting).
+    request = _bound_request(path="/other/", bound_to="/page/")
+    BaseView()._resolve_hx_token(request)
+    assert request.GET["hx_request_name"] == "simple_get"

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,78 @@
+"""Security tests for the signed round-trip token (IMPROVEMENTS #1).
+
+These assert, through a real view, that the exploits the loose-param scheme
+allowed are closed: framework data (name/object/kwargs) is only trusted when it
+arrives inside the HMAC-signed ``hx`` token. Anything a client appends to the
+raw query string is ignored, so it can neither forge context flags nor shadow
+the signed object, and malformed input fails the signature check instead of
+reaching a deserializer (no 500s).
+"""
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+from test_app import hx_requests as hx
+from test_app.views import BaseView
+
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
+from tests.helpers import add_middleware_to_request, hx_get
+
+pytestmark = pytest.mark.django_db
+
+
+def content_of(response):
+    return response.content.decode()
+
+
+def test_loose_kwarg_param_is_not_injected_into_context():
+    # Attacker appends &___flavor="forged" to a URL that carries a valid token.
+    # The loose kwarg must never reach the template context.
+    response = hx_get(hx.KwargsContextHx, BaseView, get_params={"___flavor": '"forged"'})
+    html = content_of(response)
+    assert "direct:-" in html
+    assert "forged" not in html
+
+
+def test_non_json_loose_kwarg_does_not_500():
+    # A non-JSON loose ___ param used to hit json.loads -> JSONDecodeError -> 500.
+    # It is now ignored (kwargs come only from the signed token).
+    response = hx_get(hx.KwargsContextHx, BaseView, get_params={"___flavor": "not-json"})
+    assert response.status_code == 200
+    assert "direct:-" in content_of(response)
+
+
+def test_unsigned_hx_token_is_rejected():
+    # A hand-crafted token that was never signed fails verification -> 404,
+    # not an unhandled deserializer error.
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: "totally-not-a-token"})
+    request.META["HTTP_HX_REQUEST"] = True
+    add_middleware_to_request(request)
+    with pytest.raises(Http404, match="Invalid or tampered"):
+        BaseView.as_view()(request)
+
+
+def test_resolve_strips_client_supplied_framework_params():
+    # Everything the framework trusts comes from the token; any framework params
+    # a client tacks onto the raw query string are dropped before dispatch, so
+    # they cannot shadow or forge the verified values. Non-framework params
+    # (page filters etc.) survive.
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get(
+        "/",
+        data={
+            HX_TOKEN_PARAM: token,
+            "object": "model_instance__test_app__widget__999",
+            "___evil": '"x"',
+            "hx_request_name": "other",
+            "page": "2",
+        },
+    )
+    add_middleware_to_request(request)
+
+    BaseView()._resolve_hx_token(request)
+
+    assert request.GET.get("object") is None  # loose object dropped, token had none
+    assert "___evil" not in request.GET  # loose kwarg dropped
+    assert request.GET["hx_request_name"] == "simple_get"  # from token, not "other"
+    assert request.GET["page"] == "2"  # legit loose param preserved
+    assert request._hx_kwargs == {}  # kwargs sourced only from the token

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,26 @@
 """Unit tests for hx_requests.utils: serialization, URL building, csrf."""
 
 import datetime
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.test import RequestFactory
 from test_app.models import Widget
 
 from hx_requests.utils import (
+    HX_TOKEN_PARAM,
     deserialize,
     deserialize_kwargs,
     get_csrf_token,
+    get_hx_payload,
+    get_hx_request_name,
     get_url,
     is_htmx_request,
+    is_hx_request,
     serialize,
     serialize_kwargs,
+    sign_hx_payload,
+    unsign_hx_payload,
 )
 
 # --------------------------------------------------------------------------
@@ -97,6 +104,94 @@ def test_is_htmx_request_without_header():
 
 
 # --------------------------------------------------------------------------
+# sign_hx_payload / unsign_hx_payload
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_sign_payload_round_trips_name_object_and_kwargs(widget):
+    token = sign_hx_payload("edit_widget", widget, flavor="spicy")
+    payload = unsign_hx_payload(token)
+    assert payload["name"] == "edit_widget"
+    assert deserialize(payload["object"]) == widget
+    assert deserialize_kwargs(**payload["kwargs"]) == {"flavor": "spicy"}
+
+
+def test_sign_payload_without_object_or_kwargs():
+    payload = unsign_hx_payload(sign_hx_payload("simple_get"))
+    assert payload == {"name": "simple_get", "object": None, "kwargs": {}}
+
+
+def test_tampered_token_fails_verification():
+    from django.core import signing
+
+    token = sign_hx_payload("simple_get")
+    with pytest.raises(signing.BadSignature):
+        unsign_hx_payload(token[:-3] + "xxx")
+
+
+def test_handler_name_is_bound_to_the_signature():
+    # The name lives inside the signed payload, so it cannot be swapped for
+    # another handler without invalidating the token (this is why a per-name
+    # salt is unnecessary).
+    from django.core import signing
+
+    token = sign_hx_payload("view_user")
+    forged = token.replace("view_user", "delete_user")
+    if forged != token:
+        with pytest.raises(signing.BadSignature):
+            unsign_hx_payload(forged)
+
+
+# --------------------------------------------------------------------------
+# get_hx_payload / get_hx_request_name (public introspection accessors)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_get_hx_payload_returns_verified_contents(widget):
+    token = sign_hx_payload("edit_widget", widget, flavor="spicy")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
+    payload = get_hx_payload(request)
+    assert payload["name"] == "edit_widget"
+    assert deserialize(payload["object"]) == widget
+    assert deserialize_kwargs(**payload["kwargs"]) == {"flavor": "spicy"}
+
+
+def test_get_hx_payload_none_without_token():
+    assert get_hx_payload(RequestFactory().get("/")) is None
+
+
+def test_get_hx_payload_none_on_bad_signature():
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: "not-a-real-token"})
+    assert get_hx_payload(request) is None
+
+
+def test_get_hx_request_name_reads_name_from_token():
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: sign_hx_payload("simple_get")})
+    assert get_hx_request_name(request) == "simple_get"
+
+
+def test_get_hx_request_name_none_for_plain_htmx():
+    # The plain-htmx fall-through check: no token -> not an hx handler.
+    assert get_hx_request_name(RequestFactory().get("/?page=2")) is None
+
+
+def test_is_hx_request_true_with_valid_token():
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: sign_hx_payload("simple_get")})
+    assert is_hx_request(request) is True
+
+
+def test_is_hx_request_false_without_token():
+    assert is_hx_request(RequestFactory().get("/?page=2")) is False
+
+
+def test_is_hx_request_false_on_bad_signature():
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: "garbage"})
+    assert is_hx_request(request) is False
+
+
+# --------------------------------------------------------------------------
 # get_url
 # --------------------------------------------------------------------------
 
@@ -105,36 +200,49 @@ def make_context(path="/page/", **extra):
     return {"request": RequestFactory().get(path, **extra)}
 
 
+def token_from_url(url):
+    query = parse_qs(urlparse(url).query)
+    return unsign_hx_payload(query[HX_TOKEN_PARAM][0])
+
+
 def test_get_url_basic():
     url = get_url(make_context(), "simple_get", None)
-    assert url == "/page/?hx_request_name=simple_get"
+    assert url.startswith("/page/?")
+    payload = token_from_url(url)
+    assert payload["name"] == "simple_get"
+    assert payload["object"] is None
 
 
 @pytest.mark.django_db()
 def test_get_url_includes_serialized_object(widget):
     url = get_url(make_context(), "simple_get", widget)
-    assert f"object=model_instance__test_app__widget__{widget.pk}" in url
+    assert deserialize(token_from_url(url)["object"]) == widget
 
 
 def test_get_url_appends_serialized_kwargs():
     url = get_url(make_context(), "simple_get", None, flavor="spicy")
-    assert "&___flavor=%22spicy%22" in url
+    assert deserialize_kwargs(**token_from_url(url)["kwargs"]) == {"flavor": "spicy"}
 
 
 def test_get_url_use_full_path_carries_existing_params():
     context = make_context("/page/?q=search&page=1&page=2")
     url = get_url(context, "simple_get", None, use_full_path=True)
-    assert "q=search" in url
-    assert url.count("page=") >= 2  # multi-value params preserved
+    query = parse_qs(urlparse(url).query)
+    assert query["q"] == ["search"]
+    assert query["page"] == ["1", "2"]  # multi-value params preserved
+    assert token_from_url(url)["name"] == "simple_get"
 
 
 def test_get_url_use_full_path_filters_internal_params():
     context = make_context("/page/?q=search&hx_request_name=old&object=x&___junk=%22y%22")
     url = get_url(context, "new_name", None, use_full_path=True)
-    assert "q=search" in url
-    assert "old" not in url
-    assert "junk" not in url
-    assert "object=" not in url
+    query = parse_qs(urlparse(url).query)
+    assert query["q"] == ["search"]
+    # Stale framework params from the current URL are not re-emitted loose.
+    assert "hx_request_name" not in query
+    assert "object" not in query
+    assert "___junk" not in query
+    assert token_from_url(url)["name"] == "new_name"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replaces the loose, client-editable routing params (`?hx_request_name=...&object=...&___kwarg=...`) with a single HMAC-signed `hx` token via `django.core.signing`. The token packs the `HxRequest` name, serialized object, and serialized kwargs. Clients can read it but cannot forge it without `SECRET_KEY`.

Addresses **item #1** of the security audit (and subsumes the `use_current_url` half of #6c).

## Why

The old scheme let anyone edit the URL to:

- **IDOR** — `object=...user__1` → `...user__2`: GET renders a victim's data, POST saves over it.
- **Cross-model swap** — `...user__1` → `...resident__1`: ModelForm copies overlapping fields and saves.
- **Context forgery** — append `&___can_edit=true` → injected into template context.
- **500s on garbage** — `?___note=hello` (non-JSON) → unhandled `JSONDecodeError`.

## How

- `sign_hx_payload` / `unsign_hx_payload` in `utils.py`; `get_url` emits `?hx=<token>` (non-framework params like pagination stay loose).
- `HtmxViewMixin._resolve_hx_token` verifies the token in `dispatch` and rebuilds `request.GET` from **verified data only**. Missing/tampered token → `Http404` before any deserializer runs.
- `get_hx_extra_kwargs` sources kwargs **only** from the token — never scans raw `request.GET`. This is the trust boundary that kills the `___can_edit` forgery and the garbage-500 at the source.
- `_use_current_url` strips framework keys so `HX-Current-URL` can't inject `object`/`___`kwargs.

The name lives inside the signed payload, so a token minted for one handler can't be replayed against another (a per-name salt would be redundant).

## ⚠️ Breaking change

The template tags now emit `?hx=<signed-token>` instead of `?hx_request_name=...&object=...&___kwarg=...`.

**Unchanged / source-compatible:** the `{% hx_get %}` / `{% hx_post %}` tags and `HxRequest` classes. Anyone using only those upgrades with no code change.

**What breaks:** any code that read the framework's routing data off `request.GET` — e.g. sniffing `request.GET["hx_request_name"]` to detect an hx request (a real pattern: it's how a table view tells a plain sort/filter request from an hx handler), or hand-building/parsing these URLs in tests or JS.

**Migration:** new public helpers in `hx_requests.utils` introspect a request without going through dispatch and return `None`/`False` (never raise) on a missing/tampered token:

```python
from hx_requests.utils import is_htmx_request, is_hx_request, get_hx_request_name, get_hx_payload

# was: if is_htmx_request(request) and not request.GET.get("hx_request_name"):
if is_htmx_request(request) and not is_hx_request(request):
    ...  # plain htmx fall-through

get_hx_request_name(request)  # verified name, or None
get_hx_payload(request)       # {"name", "object", "kwargs"} (serialized), or None
```

- `is_hx_request(request)` — is this a valid hx-requests request? (vs `is_htmx_request`, which only checks the `HX-Request` header).

Also: pages already rendered by the old version 404 on hx interactions until reloaded (URLs re-render signed every request, so it self-heals).

## Tests

233 passing, ruff clean. Updated the `helpers` choke point + format-asserting unit tests; added `tests/test_signing.py` (exploits closed) plus tamper/name-binding and helper tests in `test_utils.py`.

## Docs

Updated the wire-format docs (`hx_tags.rst`, `how_hx_requests_works.rst`, `object_serialization.rst`), reframed the threat model (`securing_hx_requests.rst` / `secure_hx_requests.rst`), and added a new how-to: **Detect And Inspect An HxRequest** (`how_tos/detect_hx_request.rst`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)