### PR TITLE
feat!: object-scoping hook (get_queryset / model) resolving via default manager

### DIFF
--- a/docs/explanation/object_serialization.rst
+++ b/docs/explanation/object_serialization.rst
@@ -38,6 +38,32 @@ If the received value is not a model instance, it is treated as a standard JSON 
 
 This process ensures that Django objects can be reconstructed properly when handling HTMX requests.
 
+Object scoping (``get_queryset`` / ``model``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The instance is resolved through the model's **default manager** — not
+``_base_manager``. Any scoping expressed on the default manager is therefore
+honored automatically: an object the default manager hides cannot be resolved.
+
+For row-level authorization, override :meth:`get_queryset` on the
+:code:`HxRequest` (or set :attr:`model`), exactly as you would on a Django
+:code:`UpdateView`. Resolution runs through that queryset, and a primary key
+outside it raises :code:`Http404` rather than silently loading another user's
+row:
+
+.. code-block:: python
+
+    class EditInvoiceHx(FormModalHxRequest):
+        name = "edit_invoice"
+
+        def get_queryset(self):
+            # A user can only resolve invoices they own.
+            return Invoice.objects.filter(owner=self.request.user)
+
+Because the round-trip is signed, the object reference cannot be *forged*; the
+:code:`get_queryset` seam is what stops a *replayed* reference (a token minted
+for one user's page, sent by another) from resolving out-of-scope data.
+
 Handling kwargs Serialization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/how_tos/index.rst
+++ b/docs/how_tos/index.rst
@@ -7,6 +7,7 @@ How Tos
    register_hx_requests
    detect_hx_request
    secure_hx_requests
+   scope_hx_objects
    use_modals
    oob_swap
    use_messages

--- a/docs/how_tos/scope_hx_objects.rst
+++ b/docs/how_tos/scope_hx_objects.rst
@@ -1,0 +1,80 @@
+How To Scope The hx_object Queryset
+-----------------------------------
+
+When an :code:`HxRequest` carries an object, the round-trip reference is resolved
+through :code:`get_queryset`. By default that queryset is the object's **model
+default manager**, so any scoping expressed there (soft-delete filters, tenant
+boundaries) is honored automatically, and a primary key outside the queryset
+raises :code:`Http404` instead of loading the row.
+
+That default is deliberately narrow. This guide shows how to resolve the object
+through **a different queryset** — a custom manager, a broader lookup, or a
+per-request scope.
+
+For *why* resolution is scoped and how it relates to signing, see
+:ref:`Object Serialization`.
+
+
+Set ``model``
+~~~~~~~~~~~~~
+
+The simplest override. Point the handler at a model and resolution runs through
+that model's default manager, mirroring Django's :code:`SingleObjectMixin`:
+
+.. code-block:: python
+
+    from hx_requests.hx_requests import BaseHxRequest
+
+    class EditInvoiceHx(BaseHxRequest):
+        name = "edit_invoice"
+        model = Invoice
+
+
+Override ``get_queryset``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For anything beyond the default manager, override :code:`get_queryset` and return
+the queryset you want the object resolved through. Whatever you return is the
+authoritative lookup — a pk outside it is a :code:`Http404`.
+
+**Resolve through a custom manager.**
+Use a manager other than the default — for example one that widens the lookup
+back to rows the default manager hides:
+
+.. code-block:: python
+
+    class RestoreInvoiceHx(BaseHxRequest):
+        name = "restore_invoice"
+
+        def get_queryset(self):
+            # Include soft-deleted rows the default manager filters out.
+            return Invoice.all_objects.all()
+
+**Broaden for privileged users.**
+:code:`get_queryset` runs per request, so you can widen or narrow the scope based
+on who is asking:
+
+.. code-block:: python
+
+    class EditInvoiceHx(BaseHxRequest):
+        name = "edit_invoice"
+
+        def get_queryset(self):
+            if self.request.user.is_staff:
+                return Invoice.objects.all()
+            return Invoice.objects.filter(owner=self.request.user)
+
+.. note::
+
+    Returning :code:`None` from :code:`get_queryset` (the default when no
+    :attr:`model` is set) falls back to the resolved object's own model default
+    manager. Return an explicit queryset only when you need a scope other than
+    that.
+
+.. warning::
+
+    Widening the queryset widens what a replayed reference can resolve. A token
+    minted for one user's page can be sent by another; :code:`get_queryset` is
+    the boundary that keeps resolution in scope. Only broaden it — for example
+    with :code:`all_objects` or an unfiltered :code:`objects.all()` — where the
+    handler's own checks make that safe.

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -9,7 +9,7 @@ from django.contrib import messages
 from django.contrib.messages import get_messages
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms import Form
-from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed
+from django.http import Http404, HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
@@ -17,7 +17,7 @@ from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from render_block import render_block_to_string
 
-from hx_requests.utils import deserialize
+from hx_requests.utils import deserialize, parse_model_ref, resolve_model_ref
 
 
 class Renderer:
@@ -91,6 +91,10 @@ class BaseHxRequest:
     """
 
     name: str = ""
+    #: Optional model used to scope object resolution. When set, the default
+    #: :meth:`get_queryset` resolves the round-trip object through this model's
+    #: default manager. Mirrors Django's ``SingleObjectMixin.model``.
+    model = None
     hx_object_name: str = "hx_object"
     GET_template: str | list = ""
     POST_template: str | list = ""
@@ -175,12 +179,48 @@ class BaseHxRequest:
 
         return context
 
+    def get_queryset(self):
+        """
+        The object-scoping seam. Return the queryset the round-trip object is
+        resolved through, or ``None`` to fall back to the object's own model
+        default manager.
+
+        This is the idiomatic slot for row-level authorization -- the way
+        Django CBVs teach ``get_queryset`` for the URL-pk trust boundary.
+        Override it (or set :attr:`model`) to scope resolution to objects the
+        current user may act on; a pk outside the queryset raises ``Http404``
+        rather than silently loading someone else's row::
+
+            def get_queryset(self):
+                return Invoice.objects.filter(owner=self.request.user)
+        """
+        if self.model is not None:
+            return self.model._default_manager.all()
+        return None
+
     def get_hx_object(self, request, **kwargs):
         """
-        If an 'object' was passed in, deserialize it.
+        Resolve the object carried by the (verified) round-trip token.
+
+        Model instances are resolved through :meth:`get_queryset` when it is
+        provided, so ownership scoping is honored; otherwise they fall back to
+        the model's default manager. A pk that is absent from the resolved
+        queryset raises ``Http404`` (object-level authorization), not a 500.
+        Non-model values are deserialized as plain JSON.
         """
-        if request.GET.get("object"):
-            return deserialize(request.GET.get("object"))
+        serialized = request.GET.get("object")
+        if not serialized:
+            return None
+
+        ref = parse_model_ref(serialized)
+        if ref is None:
+            return deserialize(serialized)
+
+        queryset = self.get_queryset()
+        try:
+            return resolve_model_ref(*ref, queryset=queryset)
+        except ObjectDoesNotExist:
+            raise Http404(f"No {ref[1]} matches the given query for HxRequest '{self.name}'.")
 
     def _setup_hx_request(self, request, *args, **kwargs):
         if self.get_views_context:

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -25,14 +25,43 @@ def serialize(value):
     return json.dumps(value, cls=DjangoJSONEncoder)
 
 
+def parse_model_ref(value):
+    """
+    If ``value`` is a serialized model-instance reference
+    (``model_instance__<app>__<model>__<pk>``), return ``(app_label,
+    model_name, pk)``; otherwise return ``None``. Uses a length-based slice
+    (not ``str.replace``) so a pk/label that happens to contain the prefix
+    can't be mangled.
+    """
+    if isinstance(value, str) and value.startswith(MODEL_INSTANCE_PREFIX):
+        app_label, model_name, pk = value[len(MODEL_INSTANCE_PREFIX) :].split(__)
+        return app_label, model_name, pk
+    return None
+
+
 def deserialize(value):
-    if value and value.startswith(MODEL_INSTANCE_PREFIX):
-        value = value.replace(MODEL_INSTANCE_PREFIX, "")
-        app_label, model_name, pk = value.split(__)
-        model = apps.get_model(app_label, model_name)
-        manager = model._base_manager
-        return manager.get(pk=pk)
+    ref = parse_model_ref(value)
+    if ref is not None:
+        return resolve_model_ref(*ref)
     return json.loads(value)
+
+
+def resolve_model_ref(app_label, model_name, pk, queryset=None):
+    """
+    Fetch a model instance from a parsed reference. Resolution goes through
+    ``queryset`` when one is supplied (the object-scoping seam -- see
+    ``BaseHxRequest.get_queryset``); otherwise it falls back to the model's
+    ``_default_manager``.
+
+    The default manager (not ``_base_manager``) is deliberate: any scoping
+    expressed on the default manager is respected automatically, so an object
+    the default manager hides cannot be resolved unless a handler explicitly
+    widens the queryset. Raises the model's ``DoesNotExist`` when the pk is
+    absent from the resolved queryset.
+    """
+    if queryset is None:
+        queryset = apps.get_model(app_label, model_name)._default_manager.all()
+    return queryset.get(pk=pk)
 
 
 def is_htmx_request(request):

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -9,7 +9,7 @@ fixture. Names must be unique across the whole test project.
 from django.contrib import messages
 from django.http import HttpResponse
 from test_app.forms import WidgetForm
-from test_app.models import Widget
+from test_app.models import Gadget, Widget
 
 from hx_requests.hx_requests import (
     BaseHxRequest,
@@ -182,6 +182,25 @@ class NamedObjectHx(BaseHxRequest):
 class ListEchoHx(BaseHxRequest):
     name = "list_echo"
     GET_template = "list_echo.html"
+
+
+class ScopedGadgetHx(BaseHxRequest):
+    """Scopes resolution via ``model`` -> the Gadget default manager, which
+    hides archived rows."""
+
+    name = "scoped_gadget"
+    GET_template = "object.html"
+    model = Gadget
+
+
+class QuerysetScopedHx(BaseHxRequest):
+    """Scopes resolution via an explicit ``get_queryset`` override."""
+
+    name = "queryset_scoped"
+    GET_template = "object.html"
+
+    def get_queryset(self):
+        return Widget.objects.filter(name__startswith="ok-")
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -7,3 +7,30 @@ class Widget(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class VisibleGadgetManager(models.Manager):
+    """Default manager that hides archived rows (stand-in for soft-delete)."""
+
+    def get_queryset(self):
+        return super().get_queryset().filter(archived=False)
+
+
+class Gadget(models.Model):
+    """
+    Model with a *filtering* default manager, used to prove object resolution
+    goes through ``_default_manager`` (which hides archived rows) rather than
+    ``_base_manager`` (which would expose them).
+    """
+
+    name = models.CharField(max_length=100)
+    archived = models.BooleanField(default=False)
+
+    objects = VisibleGadgetManager()  # _default_manager -- filters archived
+    all_objects = models.Manager()  # noqa: DJ012  # base manager -- sees everything
+
+    class Meta:
+        base_manager_name = "all_objects"
+
+    def __str__(self):
+        return self.name

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -241,6 +241,41 @@ def test_no_object_leaves_hx_object_none():
 
 
 # --------------------------------------------------------------------------
+# object scoping (get_queryset / model)
+# --------------------------------------------------------------------------
+
+
+def test_scoped_model_resolves_visible_object():
+    from test_app.models import Gadget
+
+    gadget = Gadget.objects.create(name="visible")
+    response = hx_get(hx.ScopedGadgetHx, BaseView, hx_kwargs={"object": gadget})
+    assert "object|visible" in content_of(response)
+
+
+def test_scoped_model_404s_object_hidden_by_default_manager():
+    from test_app.models import Gadget
+
+    # Archived rows are excluded by the default manager, so the handler's
+    # scoped queryset cannot resolve them -> 404 (not a silent load or 500).
+    archived = Gadget.all_objects.create(name="secret", archived=True)
+    with pytest.raises(Http404):
+        hx_get(hx.ScopedGadgetHx, BaseView, hx_kwargs={"object": archived})
+
+
+def test_get_queryset_override_scopes_resolution():
+    in_scope = Widget.objects.create(name="ok-mine")
+    response = hx_get(hx.QuerysetScopedHx, BaseView, hx_kwargs={"object": in_scope})
+    assert "object|ok-mine" in content_of(response)
+
+
+def test_get_queryset_override_404s_out_of_scope_object():
+    out_of_scope = Widget.objects.create(name="someone-elses")
+    with pytest.raises(Http404):
+        hx_get(hx.QuerysetScopedHx, BaseView, hx_kwargs={"object": out_of_scope})
+
+
+# --------------------------------------------------------------------------
 # use_current_url
 # --------------------------------------------------------------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.test import RequestFactory
-from test_app.models import Widget
+from test_app.models import Gadget, Widget
 
 from hx_requests.utils import (
     HX_TOKEN_PARAM,
@@ -17,6 +17,8 @@ from hx_requests.utils import (
     get_url,
     is_htmx_request,
     is_hx_request,
+    parse_model_ref,
+    resolve_model_ref,
     serialize,
     serialize_kwargs,
     sign_hx_payload,
@@ -56,11 +58,49 @@ def test_dates_serialize_via_django_json_encoder():
 
 
 @pytest.mark.django_db()
-def test_deserialize_uses_base_manager():
-    # Objects hidden by a default manager would still resolve; at minimum the
-    # base manager must be able to fetch a plain instance by pk.
-    widget = Widget.objects.create(name="managed")
-    assert deserialize(serialize(widget)).pk == widget.pk
+def test_deserialize_uses_default_manager():
+    # Resolution goes through the *default* manager, so anything the default
+    # manager hides (soft-delete / tenant scoping) cannot be resolved. A
+    # visible row still resolves fine.
+    gadget = Gadget.objects.create(name="visible")
+    assert deserialize(serialize(gadget)).pk == gadget.pk
+
+    archived = Gadget.all_objects.create(name="archived", archived=True)
+    with pytest.raises(Gadget.DoesNotExist):
+        deserialize(serialize(archived))
+
+
+# --------------------------------------------------------------------------
+# parse_model_ref / resolve_model_ref
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_parse_model_ref_splits_a_model_reference(widget):
+    assert parse_model_ref(serialize(widget)) == ("test_app", "widget", str(widget.pk))
+
+
+@pytest.mark.parametrize("value", ['"hello"', "5", "true", "null", '{"a": 1}'])
+def test_parse_model_ref_returns_none_for_non_model_values(value):
+    assert parse_model_ref(value) is None
+
+
+@pytest.mark.django_db()
+def test_resolve_model_ref_uses_default_manager_by_default():
+    gadget = Gadget.objects.create(name="visible")
+    ref = ("test_app", "gadget", str(gadget.pk))
+    assert resolve_model_ref(*ref) == gadget
+
+
+@pytest.mark.django_db()
+def test_resolve_model_ref_honors_a_scoped_queryset(widget):
+    other = Widget.objects.create(name="out-of-scope")
+    scoped = Widget.objects.filter(pk=widget.pk)
+    # In-scope pk resolves...
+    assert resolve_model_ref("test_app", "widget", str(widget.pk), queryset=scoped) == widget
+    # ...out-of-scope pk is not found (the object-authz boundary).
+    with pytest.raises(Widget.DoesNotExist):
+        resolve_model_ref("test_app", "widget", str(other.pk), queryset=scoped)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements **item #2** of the audit remediation plan: gives object resolution an idiomatic ownership-scoping seam and closes the `_base_manager` over-reach.

> Stacked on #1 (signing) — base branch is `feat/sign-round-trip`. Review/merge #193 first.

Two load-bearing changes:

1. **Default manager, not base manager.** Resolution now goes through the model's `_default_manager` instead of `_base_manager`. Soft-delete / tenant scoping expressed on the default manager is honored automatically — an object the default manager hides can no longer be resolved.
2. **`get_queryset()` scoping seam.** `BaseHxRequest.get_queryset()` (or setting `model`) is the documented slot for row-level authorization, mirroring Django's `SingleObjectMixin`. `get_hx_object` resolves the signed reference through it; a pk outside the queryset raises `Http404` instead of loading another user's row or 500-ing.

Signing (#1) stops *forging* an object reference; this stops a *replayed* reference (a token from one user's page, sent by another) from resolving out-of-scope data.

## Implementation

- `utils.parse_model_ref` — length-based slice (not `str.replace`, which could mangle a pk/label containing the prefix).
- `utils.resolve_model_ref(app, model, pk, queryset=None)` — resolves through the given queryset or the default manager.
- `BaseHxRequest.get_queryset()` / `model` / rewritten `get_hx_object`.

## Breaking change

Handlers that relied on `_base_manager` resolving default-manager-hidden rows must set `model` with an explicit `base_manager_name` or override `get_queryset`.

## Tests

+12 tests: `parse_model_ref`/`resolve_model_ref` units, default-manager filtering (new `Gadget` fixture model with a filtering default manager), and handler-level scoping (model-based and `get_queryset`-override, both asserting `Http404` out of scope). Full suite: **245 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)