### PR TITLE
fix!: chain non-HTMX dispatch through super() + auth-mixin ordering check (#3)

### DIFF
--- a/docs/how_tos/secure_hx_requests.rst
+++ b/docs/how_tos/secure_hx_requests.rst
@@ -14,6 +14,33 @@ For an explanation of *why* these controls exist and the risks they prevent,
 see :ref:`Why HxRequest Security Is Needed <why-hxrequest-security>`.
 
 
+Ordering Django auth mixins on the view
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you combine :code:`HtmxViewMixin` with a Django auth mixin
+(:code:`LoginRequiredMixin`, :code:`PermissionRequiredMixin`,
+:code:`UserPassesTestMixin`), **put the auth mixin first**:
+
+.. code-block:: python
+
+    # Correct: LoginRequiredMixin.dispatch runs before the HTMX handoff, so it
+    # gates both full page loads AND HTMX requests.
+    class MyView(LoginRequiredMixin, HtmxViewMixin, ListView):
+        ...
+
+    # Trap: the auth mixin is skipped on the HTMX path.
+    class MyView(HtmxViewMixin, LoginRequiredMixin, ListView):
+        ...
+
+:code:`HtmxViewMixin.dispatch` hands HTMX requests to the resolved
+:code:`HxRequest` without calling :code:`super().dispatch()`, so an auth mixin
+listed *after* it never runs for HTMX requests. Full page loads chain through
+:code:`super().dispatch()` normally, so the mixin still gates those — but the
+HTMX path would be silently unauthenticated. A Django system check
+(:code:`hx_requests.W001`) warns at startup / :code:`manage.py check` when the
+ordering is wrong.
+
+
 Global Settings
 ~~~~~~~~~~~~~~~
 

--- a/hx_requests/apps.py
+++ b/hx_requests/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class HxRequestsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "hx_requests"
+
+    def ready(self):
+        # Register system checks (e.g. auth-mixin ordering on HtmxViewMixin views).
+        from hx_requests import checks  # noqa: F401

--- a/hx_requests/checks.py
+++ b/hx_requests/checks.py
@@ -1,0 +1,71 @@
+"""
+Django system checks for hx-requests.
+
+These surface configuration mistakes at startup / ``manage.py check`` rather
+than as silent runtime surprises.
+"""
+
+from __future__ import annotations
+
+from django.core.checks import Warning, register
+
+W_AUTH_MIXIN_ORDER = "hx_requests.W001"
+
+
+def _all_subclasses(cls):
+    for sub in cls.__subclasses__():
+        yield sub
+        yield from _all_subclasses(sub)
+
+
+@register()
+def check_auth_mixin_ordering(app_configs, **kwargs):
+    """
+    Warn when a Django auth mixin (any ``AccessMixin`` subclass --
+    ``LoginRequiredMixin``, ``PermissionRequiredMixin``,
+    ``UserPassesTestMixin``) is listed *after* ``HtmxViewMixin`` in a view's
+    base classes.
+
+    ``HtmxViewMixin.dispatch`` hands HTMX requests off to the resolved
+    ``HxRequest`` without calling ``super().dispatch()``, so any auth mixin
+    ordered after it never runs on the HTMX path -- authentication is silently
+    skipped for HTMX requests with no error. Auth mixins must come *before*
+    ``HtmxViewMixin`` so their ``dispatch`` runs first (or authorization must be
+    enforced per-handler on the ``HxRequest``).
+
+    Best effort: only view classes that have been imported are visible via
+    ``__subclasses__``; this catches the common case at startup.
+    """
+    from django.contrib.auth.mixins import AccessMixin
+
+    from hx_requests.views import HtmxViewMixin
+
+    errors = []
+    for view_cls in _all_subclasses(HtmxViewMixin):
+        mro = view_cls.__mro__
+        try:
+            hx_index = mro.index(HtmxViewMixin)
+        except ValueError:  # pragma: no cover - defensive
+            continue
+
+        for later in mro[hx_index + 1 :]:
+            if later is not AccessMixin and issubclass(later, AccessMixin):
+                errors.append(
+                    Warning(
+                        f"{view_cls.__module__}.{view_cls.__qualname__} lists the auth "
+                        f"mixin {later.__name__} after HtmxViewMixin.",
+                        hint=(
+                            "HtmxViewMixin.dispatch routes HTMX requests to the HxRequest "
+                            "handler without calling super().dispatch(), so an auth mixin "
+                            "placed after it is skipped on the HTMX path and authentication "
+                            "is silently bypassed. Put auth mixins BEFORE HtmxViewMixin in "
+                            "the base-class list, and/or enforce authorization per-handler "
+                            "on the HxRequest."
+                        ),
+                        obj=view_cls,
+                        id=W_AUTH_MIXIN_ORDER,
+                    )
+                )
+                break
+
+    return errors

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -33,23 +33,27 @@ class HtmxViewMixin:
     use_global_hx_rules: bool = True  # True by default
 
     def dispatch(self, request, *args, **kwargs):
-        # Try to dispatch to the right method; if a method doesn't exist,
-        # defer to the error handler. Also defer to the error handler if the
-        # request method isn't on the approved list.
-        if request.method.lower() in self.http_method_names:
-            # If it's an HTMX request, hand off to the resolved HxRequest's
-            # own dispatch; otherwise, let the view class handle the request.
-            if is_htmx_request(request):
-                request = self._resolve_hx_token(request)
-                kwargs.update(self.get_hx_extra_kwargs(request))
-                hx_request = self._setup_hx_request(request, *args, **kwargs)
+        # HTMX requests are handed off to the resolved HxRequest's own dispatch.
+        # super().dispatch() is deliberately NOT called on this path: it would
+        # route to the page view's own get/post and defeat the handoff. As a
+        # consequence the page view's dispatch-based auth mixins
+        # (LoginRequiredMixin, PermissionRequiredMixin, ...) only gate this path
+        # when they sit *before* HtmxViewMixin in the MRO -- otherwise the
+        # handoff runs first and skips them. `check_auth_mixin_ordering`
+        # (checks.py) warns at startup when an auth mixin is ordered after this
+        # mixin; enforce per-handler authorization on the HxRequest itself.
+        if is_htmx_request(request) and request.method.lower() in self.http_method_names:
+            request = self._resolve_hx_token(request)
+            kwargs.update(self.get_hx_extra_kwargs(request))
+            hx_request = self._setup_hx_request(request, *args, **kwargs)
 
-                # Use request from hx_request, in case use_current_url is set to True
-                return hx_request.dispatch(hx_request.request, *args, **kwargs)
-            handler = getattr(self, request.method.lower(), self.http_method_not_allowed)
-        else:
-            handler = self.http_method_not_allowed
-        return handler(request, *args, **kwargs)
+            # Use request from hx_request, in case use_current_url is set to True
+            return hx_request.dispatch(hx_request.request, *args, **kwargs)
+
+        # Non-HTMX requests (full page loads, plain-htmx the view handles
+        # itself) chain through super().dispatch() so the page view's own
+        # mixins run normally instead of being short-circuited.
+        return super().dispatch(request, *args, **kwargs)
 
     def get_hx_request(self, request):
         hx_request_name = request.GET.get("hx_request_name")

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import ListView, TemplateView, UpdateView
 from test_app.models import Widget
 
@@ -56,3 +57,24 @@ class StrictAllowListView(BaseView):
 
     allowed_hx_requests = ["simple_get"]
     use_global_hx_rules = False
+
+
+class AuthAfterHxView(HtmxViewMixin, LoginRequiredMixin, TemplateView):
+    """
+    Auth mixin ordered *after* HtmxViewMixin -- the trap the system check flags.
+    Non-HTMX requests are still gated now that dispatch chains via super(); the
+    HTMX path is not (that needs per-handler auth).
+
+    ``raise_exception`` makes an unauthenticated request 403 instead of
+    redirecting, so the test doesn't depend on a login URL / URLconf.
+    """
+
+    template_name = "base_view.html"
+    raise_exception = True
+
+
+class AuthBeforeHxView(LoginRequiredMixin, HtmxViewMixin, TemplateView):
+    """Correct ordering: auth mixin before HtmxViewMixin gates every path."""
+
+    template_name = "base_view.html"
+    login_url = "/login/"

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -397,3 +397,18 @@ def test_unknown_hx_request_name_raises_404():
     add_middleware_to_request(request)
     with pytest.raises(Http404, match="No HxRequest found"):
         BaseView.as_view()(request)
+
+
+def test_non_htmx_request_chains_through_auth_mixin_after_htmxviewmixin():
+    from django.contrib.auth.models import AnonymousUser
+    from django.core.exceptions import PermissionDenied
+    from test_app.views import AuthAfterHxView
+
+    # A full page load by an anonymous user must be gated by LoginRequiredMixin
+    # even though it sits after HtmxViewMixin -- proving dispatch now chains via
+    # super() instead of short-circuiting straight to the view's get().
+    request = RequestFactory().get("/")
+    request.user = AnonymousUser()
+    add_middleware_to_request(request)
+    with pytest.raises(PermissionDenied):
+        AuthAfterHxView.as_view()(request)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,23 @@
+"""Tests for hx_requests.checks (Django system checks)."""
+
+# Importing the views registers them as HtmxViewMixin subclasses so the check
+# (which walks __subclasses__) can see them.
+from test_app.views import AuthAfterHxView, AuthBeforeHxView  # noqa: F401
+
+from hx_requests.checks import W_AUTH_MIXIN_ORDER, check_auth_mixin_ordering
+
+
+def _flagged_view_names():
+    return {
+        getattr(warning.obj, "__name__", None)
+        for warning in check_auth_mixin_ordering(app_configs=None)
+        if warning.id == W_AUTH_MIXIN_ORDER
+    }
+
+
+def test_warns_when_auth_mixin_is_after_htmxviewmixin():
+    assert "AuthAfterHxView" in _flagged_view_names()
+
+
+def test_does_not_warn_when_auth_mixin_is_before_htmxviewmixin():
+    assert "AuthBeforeHxView" not in _flagged_view_names()


### PR DESCRIPTION
## Summary

Implements **item #3** of the audit plan: fixes the `dispatch` chain so the page view's auth mixins are no longer silently short-circuited, and adds a system check for the MRO trap.

> Stacked on #2 (`feat/object-scoping-hook`), which is stacked on #1. Merge in order.

`HtmxViewMixin.dispatch` never called `super().dispatch()`. On the non-HTMX path it did its own handler lookup, so any dispatch-based mixin on the page view (`LoginRequiredMixin`, `PermissionRequiredMixin`, …) was skipped — auth could be silently bypassed depending on MRO order, with no warning.

## Changes

- **Non-HTMX path** now `return super().dispatch(...)`, so page-view mixins chain normally on full page loads.
- **HTMX path** is unchanged — it hands off to the resolved `HxRequest` *without* `super()` (calling it would route to the page view's own `get`/`post` and defeat the handoff). Consequence: auth mixins only gate the HTMX path when placed **before** `HtmxViewMixin`; otherwise enforce per-handler auth on the `HxRequest` (this previews #9).
- **New system check** `hx_requests.W001` (registered in `AppConfig.ready`) warns when an `AccessMixin` subclass is ordered *after* `HtmxViewMixin` in a view's MRO — surfacing the trap at startup / `manage.py check` rather than as a mystery bypass.

## Tests

- Anonymous full page load is now gated by a `LoginRequiredMixin` placed *after* `HtmxViewMixin` (403) — proving dispatch chains via `super()`.
- System-check coverage for both orderings (`test_checks.py`).
- Existing dispatch/routing/security tests unchanged and green. Full suite: **248 passed**.

Docs: added a "Ordering Django auth mixins on the view" section to the security how-to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)