### PR TITLE
fix!: use Django CSRF/HTML primitives for template-tag string-craft (#6a + #6b)

### DIFF
--- a/hx_requests/templatetags/hx_tags.py
+++ b/hx_requests/templatetags/hx_tags.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from django import template
+import json
 
-from hx_requests.utils import get_csrf_token, get_url
+from django import template
+from django.middleware.csrf import get_token
+from django.utils.html import format_html
+
+from hx_requests.utils import get_url
 
 register = template.Library()
 
@@ -14,7 +18,7 @@ def hx_get(context: dict, hx_request_name: str, object=None, use_full_path=False
     And includes the hx_request_name, object, and any additional kwargs.
     """
     url = get_url(context, hx_request_name, object, use_full_path, **kwargs)
-    return f"hx-get={url}"
+    return format_html('hx-get="{}"', url)
 
 
 @register.simple_tag(takes_context=True)
@@ -25,10 +29,15 @@ def hx_post(context: dict, hx_request_name: str, object=None, use_full_path=Fals
     Also includes the CSRF token if available.
     """
     url = get_url(context, hx_request_name, object, use_full_path, **kwargs)
-    hx_attrs = f"hx-post={url}"
-    token = get_csrf_token(context)
+    hx_attrs = format_html('hx-post="{}"', url)
+    # get_token delegates to Django: it handles CSRF_USE_SESSIONS, token
+    # masking/rotation, and custom cookie names, and always mints a usable token
+    # from the request (so a POST is never left without its CSRF header).
+    token = get_token(context["request"])
     if token:
-        hx_attrs += f' hx-headers={{"X-CSRFTOKEN":"{token}"}}'
+        # Single-quote the attribute so the JSON's double quotes survive; they
+        # are HTML-escaped by format_html and decoded by the browser at parse time.
+        hx_attrs += format_html(" hx-headers='{}'", json.dumps({"X-CSRFTOKEN": token}))
     return hx_attrs
 
 

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -195,10 +195,3 @@ def _handler_binds_to_path(hx_request_name):
     hx_request_class = HxRequestRegistry.get_hx_request(hx_request_name)
     # Path-binding is on by default; a handler opts out with bind_to_path = False.
     return bool(getattr(hx_request_class, "bind_to_path", True))
-
-
-def get_csrf_token(context):
-    cookie = context["request"].headers.get("cookie")
-    if cookie and "csrftoken" in cookie:
-        token = cookie.split("csrftoken=")[1].split(";")[0]
-        return token

--- a/tests/test_hx_tags.py
+++ b/tests/test_hx_tags.py
@@ -1,5 +1,8 @@
 """Tests for the hx_tags template tags."""
 
+import html
+import json
+import re
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -14,16 +17,24 @@ def make_context(path="/page/", **extra):
     return {"request": RequestFactory().get(path, **extra)}
 
 
-def payload_from_attr(attr):
-    # attr looks like `hx-get=/page/?hx=<token>` (optionally with more attrs).
-    url = attr.split("=", 1)[1].split(" ", 1)[0]
+def attr_value(attr, name):
+    # Attributes are emitted quoted, e.g. `hx-get="/page/?hx=<token>"`; the URL
+    # is HTML-escaped inside the quotes, so unescape before parsing.
+    match = re.search(rf"""{name}=(["'])(.*?)\1""", attr)
+    assert match, f"{name} not found in {attr!r}"
+    return html.unescape(match.group(2))
+
+
+def payload_from_attr(attr, name="hx-get"):
+    url = attr_value(attr, name)
     query = parse_qs(urlparse(url).query)
     return unsign_hx_payload(query[HX_TOKEN_PARAM][0])
 
 
-def test_hx_get_renders_attribute():
+def test_hx_get_renders_quoted_attribute():
     out = hx_get(make_context(), "simple_get")
-    assert out.startswith("hx-get=/page/?")
+    assert out.startswith('hx-get="/page/?')
+    assert out.endswith('"')
     assert payload_from_attr(out)["name"] == "simple_get"
 
 
@@ -36,17 +47,26 @@ def test_hx_get_includes_object_and_kwargs(widget):
     assert deserialize_kwargs(**payload["kwargs"]) == {"flavor": "spicy"}
 
 
-def test_hx_post_includes_csrf_headers_from_cookie():
-    context = make_context(HTTP_COOKIE="csrftoken=tok123")
-    out = hx_post(context, "simple_get")
-    assert out.startswith("hx-post=/page/?")
-    assert payload_from_attr(out)["name"] == "simple_get"
-    assert 'hx-headers={"X-CSRFTOKEN":"tok123"}' in out
-
-
-def test_hx_post_without_csrf_cookie_omits_headers():
+def test_hx_post_renders_quoted_attribute_and_csrf_headers():
     out = hx_post(make_context(), "simple_get")
-    assert "hx-headers" not in out
+    assert out.startswith('hx-post="/page/?')
+    assert payload_from_attr(out, "hx-post")["name"] == "simple_get"
+
+    # hx-headers is emitted as a quoted attribute carrying JSON; the JSON's
+    # double quotes are HTML-escaped inside the attribute value.
+    headers = json.loads(attr_value(out, "hx-headers"))
+    token = headers["X-CSRFTOKEN"]
+    assert isinstance(token, str)
+    # get_token returns a masked 64-char token regardless of CSRF config.
+    assert len(token) == 64
+
+
+def test_hx_post_always_includes_csrf_headers():
+    # get_token mints a token from the request regardless of cookies, so the
+    # CSRF header is always present (previously it was dropped when no
+    # csrftoken cookie was set, silently breaking POSTs).
+    assert "hx-headers" in hx_post(make_context(), "simple_get")
+    assert "hx-headers" in hx_post(make_context(HTTP_COOKIE="a=b"), "simple_get")
 
 
 def test_hx_url_returns_bare_url():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,6 @@ from hx_requests.utils import (
     HX_TOKEN_PARAM,
     deserialize,
     deserialize_kwargs,
-    get_csrf_token,
     get_hx_payload,
     get_hx_request_name,
     get_url,
@@ -283,23 +282,3 @@ def test_get_url_use_full_path_filters_internal_params():
     assert "object" not in query
     assert "___junk" not in query
     assert token_from_url(url)["name"] == "new_name"
-
-
-# --------------------------------------------------------------------------
-# get_csrf_token
-# --------------------------------------------------------------------------
-
-
-def test_get_csrf_token_reads_cookie():
-    context = make_context(HTTP_COOKIE="csrftoken=tok123; other=1")
-    assert get_csrf_token(context) == "tok123"
-
-
-def test_get_csrf_token_with_leading_cookies():
-    context = make_context(HTTP_COOKIE="a=b; csrftoken=tok456")
-    assert get_csrf_token(context) == "tok456"
-
-
-def test_get_csrf_token_missing_returns_none():
-    assert get_csrf_token(make_context(HTTP_COOKIE="a=b")) is None
-    assert get_csrf_token(make_context()) is None


### PR DESCRIPTION
## Summary

Implements **item #6** (6a + 6b) of the audit plan — replaces two pieces of fragile hand-rolled string-craft in the template tags with Django primitives.

> Stacked on the security work — base branch is `fix/dispatch-chain-mro` (#1+#2+#3). `#6c` (raw-input deserialize) was already subsumed by #1 signing.

## 6a — CSRF token

`get_csrf_token` hand-split the raw `Cookie` header on `"csrftoken="`:

- **Breaks `CSRF_USE_SESSIONS = True`** — no `csrftoken` cookie → returns nothing → every `hx_post` POST 403s.
- **Wrong token** if another cookie name contains `csrftoken`.

Now delegates to `django.middleware.csrf.get_token(request)`, which mints a masked token from the request under any CSRF configuration (sessions, custom cookie name, masking/rotation). `hx_post` therefore always emits a valid `X-CSRFTOKEN`.

## 6b — unquoted HTML attributes

`hx_get`/`hx_post` emitted `hx-get={url}` and `hx-headers={...}` **without quotes** — working only because the encoded values happened to contain no spaces (one space truncates the attribute). They now build attributes with `format_html` (quoted + HTML-escaped). `hx-headers` is single-quoted so its JSON double-quotes survive as entities the browser decodes at parse time.

This matches the wire format the docs **already show** (`hx-get="..."` in `hx_tags.rst`) — the code was the thing out of step.

Verified end-to-end through the template engine: `hx-post="/page/?hx=<token>" hx-headers='{&quot;X-CSRFTOKEN&quot;: &quot;...&quot;}'` decodes to valid JSON.

## Breaking change

The tags now emit **quoted** attributes and always include the CSRF header. Anyone asserting on the exact unquoted string (`hx-get=/path`) or relying on the header being omitted when no cookie is present must update.

## Tests

Rewrote the CSRF and tag-format unit tests to assert the new behavior (token minted regardless of cookie; quoted attributes; `hx-headers` JSON round-trips). Full suite: **247 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)