### PR TITLE
refactor!: tighten template/error-message/model-name API surface (#7)

### DIFF
--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -13,8 +13,7 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseNotAllow
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
-from django.utils.html import strip_tags
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html, strip_tags
 from render_block import render_block_to_string
 
 from hx_requests.utils import deserialize, parse_model_ref, resolve_model_ref
@@ -249,7 +248,14 @@ class BaseHxRequest:
             _ = self.view_response
 
     def hx_object_to_str(self) -> str:
-        return self.hx_object._meta.model.__name__.capitalize() if self.hx_object else ""
+        if not self.hx_object:
+            return ""
+        # Use the model's verbose_name rather than str.capitalize() on the class
+        # name -- capitalize() lower-cased the tail of CamelCase names ("MyModel"
+        # -> "Mymodel"). Upper-case only the first character so the name reads as
+        # a proper noun at the start of the success/error messages.
+        verbose_name = str(self.hx_object._meta.verbose_name)
+        return verbose_name[:1].upper() + verbose_name[1:]
 
     def get_headers(self, **kwargs) -> dict:
         """
@@ -371,8 +377,9 @@ class BaseHxRequest:
         render_with_context = partial(self.renderer.render, context=context, request=self.request)
         html = []
 
-        # Case: Single template, single block
-        if isinstance(templates, str) and isinstance(blocks, str):
+        # Case: Single template, single block (or no block). A falsy block name
+        # renders the whole template, so `None` and `""` both mean "no block".
+        if isinstance(templates, str) and (blocks is None or isinstance(blocks, str)):
             return render_with_context(templates, blocks)
 
         # Case: Multiple templates and blocks provided as a dictionary
@@ -404,7 +411,13 @@ class BaseHxRequest:
                 )
             return "".join(render_with_context(templates, block) for block in blocks)
 
-        return ""
+        # No branch matched: the template/block types are unsupported. Fail loud
+        # instead of silently returning an empty partial (which surfaces later as
+        # a mystifying blank swap).
+        raise ValueError(
+            f"Unsupported template/block combination: templates={templates!r}, blocks={blocks!r}. "
+            "templates must be a str or list; blocks must be a str, list, dict, or None."
+        )
 
     def _get_messages_html(self, **kwargs) -> str:
         messages = get_messages(self.request)
@@ -599,14 +612,15 @@ class FormHxRequest(BaseHxRequest):
         Message set when the form is invalid. Override to set
         a custom message.
         """
-        message = (
-            f"<b>{self.hx_object_to_str()} did not save  successfully.</b>"
-            if self.hx_object
-            else "<b>Did not save successfully</b>"
-        )
+        if self.hx_object:
+            message = format_html("<b>{} did not save successfully.</b>", self.hx_object_to_str())
+        else:
+            message = format_html("<b>{}</b>", "Did not save successfully")
         if self.add_form_errors_to_error_message:
-            message += mark_safe("</br>") + self.get_form_errors(**kwargs)
-        return mark_safe(message)
+            # format_html escapes each interpolated part and returns a SafeString;
+            # <br> is the valid line break (the old code emitted the invalid </br>).
+            message = format_html("{}<br>{}", message, self.get_form_errors(**kwargs))
+        return message
 
     def get_form_errors(self, **kwargs) -> str:
         """

--- a/tests/test_renderer_unit.py
+++ b/tests/test_renderer_unit.py
@@ -1,5 +1,6 @@
 """Unit tests for the Renderer template/block dispatcher."""
 
+import pytest
 from django.test import RequestFactory
 from test_app.hx_requests import SimpleGetHx
 
@@ -17,11 +18,22 @@ def test_renders_only_the_named_block():
     assert html == "block-content"
 
 
-def test_render_templates_returns_empty_for_unmatched_shapes():
+def _bare_hx():
     hx = SimpleGetHx()
     hx.request = RequestFactory().get("/")
     hx.renderer = Renderer()
     hx.view_response = None
     hx.hx_object = None
-    # blocks=None matches no template/block case and falls through to "".
-    assert hx._render_templates("simple.html", None) == ""
+    return hx
+
+
+def test_render_templates_renders_whole_template_when_block_is_none():
+    # A single template with no block renders the whole template (a falsy block
+    # name means "no block"), rather than silently returning "".
+    html = _bare_hx()._render_templates("simple.html", None)
+    assert "simple-template" in html
+
+
+def test_render_templates_raises_on_unsupported_shapes():
+    with pytest.raises(ValueError, match="Unsupported template/block combination"):
+        _bare_hx()._render_templates("simple.html", 123)


### PR DESCRIPTION
## Summary

Implements **item #7** of the audit plan — three small API-surface cleanups.

> Stacked on #4 (`perf/lazy-view-context`) → #6 → the security stack. Merge in order.

## 7a — `_render_templates` fails loud

The four-branch shape dispatch silently returned `""` when nothing matched — a misconfigured handler produced a mystifying blank swap. It now:
- **raises a descriptive `ValueError`** naming the offending `templates`/`blocks` types, and
- **renders the whole template for a single template with a `None` block** (a falsy block name has always meant "no block"), instead of falling through to `""`.

## 7b — `get_error_message` uses `format_html`, emits valid `<br>`

Was building HTML by `mark_safe`-ing an interpolated f-string, and emitted the **invalid `</br>`** tag. Now uses `format_html` (each interpolated part escaped, result a `SafeString`) and the valid `<br>`. `mark_safe` is no longer imported. Kept as an overridable method rather than extracting a template, so the `get_error_message`/`get_success_message` override contract is unchanged.

## 7c — `hx_object_to_str` uses `verbose_name`

`str.capitalize()` on the class name lower-cased the tail of CamelCase names (`MyModel` → `Mymodel`). Now uses `_meta.verbose_name` with the first character upper-cased. Single-word names like `Widget` are unaffected (still `Widget`).

## Breaking change

`_render_templates` now raises on unsupported shapes and renders (rather than blanks) a single-template/`None`-block call; multi-word model names in the default success/error messages change from mangled CamelCase to the verbose name.

## Tests

Rewrote the renderer fall-through unit test into render-whole-template + raise-on-unsupported cases. Existing message/render tests stay green. Full suite: **252 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)