### PR TITLE
feat: mount HxRequests on real URLs — the #10 additive router

### DIFF
--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -128,5 +128,20 @@ Path-binding adds a *where* constraint on top: a token verifies only on the
 path it was rendered on, unless a handler opts out with
 :code:`bind_to_path = False`.
 
+.. note::
+
+    **On the URL router the replay window narrows further.** When handlers are
+    mounted on their own URLs (see :ref:`How To Mount HxRequests on URLs
+    <how-to-mount-on-urls>`), the handler name comes from the URL path, not the
+    token, and the endpoint rejects a token whose name doesn't match the URL it
+    arrived on (:code:`Http404`). A token for :code:`edit_widget` can no longer
+    even be *replayed against another handler's endpoint* — though per-handler
+    authorization is still what decides whether *this user* may run it, and
+    remains the primary defense on both the router and the legacy path. Because
+    the router endpoint is a real Django :code:`View`, Django's own
+    :code:`login_required` / :code:`LoginRequiredMixin` also compose natively
+    with it. Path-binding composes too: :func:`get_url` binds the token to the
+    router endpoint URL it targets, so :code:`bind_to_path` still verifies there.
+
 Continue to :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 for configuration examples.

--- a/docs/explanation/securing_hx_requests.rst
+++ b/docs/explanation/securing_hx_requests.rst
@@ -140,8 +140,12 @@ path it was rendered on, unless a handler opts out with
     remains the primary defense on both the router and the legacy path. Because
     the router endpoint is a real Django :code:`View`, Django's own
     :code:`login_required` / :code:`LoginRequiredMixin` also compose natively
-    with it. Path-binding composes too: :func:`get_url` binds the token to the
-    router endpoint URL it targets, so :code:`bind_to_path` still verifies there.
+    with it. Path-binding (:code:`bind_to_path`) is a *legacy-dispatch* concept
+    and is redundant on the router: the endpoint's name-binding already blocks
+    cross-handler replay and each handler has its own URL, so router-minted
+    tokens are not path-bound. Enforcement still honors a :code:`path` claim if
+    one is present, so a legacy-minted bound token replayed at an endpoint is
+    still rejected.
 
 Continue to :ref:`How To Secure HxRequests <how-to-secure-hxrequests>`
 for configuration examples.

--- a/docs/how_tos/index.rst
+++ b/docs/how_tos/index.rst
@@ -5,6 +5,7 @@ How Tos
    :maxdepth: 1
 
    register_hx_requests
+   mount_on_urls
    detect_hx_request
    secure_hx_requests
    scope_hx_objects

--- a/docs/how_tos/mount_on_urls.rst
+++ b/docs/how_tos/mount_on_urls.rst
@@ -78,6 +78,18 @@ Because the endpoint is a real Django :code:`View`, Django's own
 with it, and the :code:`hx_requests.W001` mixin-ordering trap does not apply on
 this path (there is no page view to short-circuit).
 
+.. note::
+
+    **Path-binding (**:code:`bind_to_path`\ **) is a legacy-dispatch concept and
+    is redundant here.** It exists because query-param dispatch hides the handler
+    behind the page URL, so the token is pinned to its render path to narrow
+    cross-page replay. On the router each handler has its own URL and the endpoint
+    enforces name-binding, so router-minted tokens are simply not path-bound. (A
+    handler's :code:`bind_to_path` setting still applies on the legacy path, and
+    the endpoint still rejects a token that carries a mismatched :code:`path`
+    claim.) When the router eventually becomes the only dispatch path,
+    :code:`bind_to_path` can be retired.
+
 Sharing page-view context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/how_tos/mount_on_urls.rst
+++ b/docs/how_tos/mount_on_urls.rst
@@ -1,0 +1,115 @@
+.. _how-to-mount-on-urls:
+
+How To Mount HxRequests on URLs
+-------------------------------
+
+By default, :code:`hx-requests` routes every request through the page view that
+carries :code:`HtmxViewMixin`: the handler name rides inside the signed
+:code:`hx` token and the mixin dispatches to it. The **URL router** is an
+additive alternative that gives every registered handler its own real Django
+URL (:code:`/hx/<name>/`), so :code:`reverse()`, URL-level decorators and
+middleware, per-endpoint caching, and :code:`show_urls` all work.
+
+It is **opt-in and additive**: until you wire it up nothing changes, and once
+you do, your templates need no edits — the :code:`hx_get` / :code:`hx_post` tags
+start emitting the router URL automatically.
+
+Wiring it up
+~~~~~~~~~~~~~
+
+Add the generated patterns to your root URLconf once. The registry builds one
+:code:`path()` per registered handler *name* — you never hand-author a URL per
+handler:
+
+.. code-block:: python
+
+    # urls.py
+    from django.urls import include, path
+
+    from hx_requests.hx_registry import HxRequestRegistry
+
+    urlpatterns = [
+        # ... your other URLs ...
+        path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+    ]
+
+:code:`HxRequestRegistry.get_urls()` returns the URL patterns. Handler classes
+are **not** imported when the URLs are built — only their names are needed — so
+lazy loading is preserved. The patterns are a snapshot taken when the URLconf is
+built, so **adding a new handler needs a server restart** (the same as any
+URLconf change).
+
+That is all. :code:`reverse("hx:edit_widget")` now resolves to
+:code:`/hx/edit_widget/`, and the template tags reverse it for you.
+
+.. note::
+
+    The namespace is the fixed string :code:`hx`, so handlers reverse as
+    :code:`hx:<name>`.
+
+Templates are unchanged
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You do not touch your templates. :code:`{% hx_get %}`, :code:`{% hx_post %}` and
+:code:`{% hx_url %}` prefer the router URL when it is installed and fall back to
+the current page's path (legacy dispatch) when it is not:
+
+.. code-block:: html
+
+    <!-- Emits hx-get="/hx/edit_widget/?hx=<token>" when the router is wired,
+         or hx-get="<current-path>?hx=<token>" when it is not. -->
+    <button {% hx_get 'edit_widget' widget %}>Edit</button>
+
+The signed :code:`hx` token still carries the handler name, object, and kwargs,
+so request signing composes with the router unchanged.
+
+Path binding (a security bonus)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On the router the handler name comes from the **URL path**, not from a client
+parameter. The endpoint checks that the token's name matches the URL it arrived
+on, so a token minted for :code:`edit_widget` **cannot be replayed** against
+:code:`delete_widget`'s URL — the mismatch is rejected with :code:`Http404`.
+Per-handler authorization (:code:`login_required` / :code:`permission_required`
+/ :code:`has_permission`) runs exactly as it does on the legacy path.
+
+Because the endpoint is a real Django :code:`View`, Django's own
+:code:`login_required` decorator and :code:`LoginRequiredMixin` compose natively
+with it, and the :code:`hx_requests.W001` mixin-ordering trap does not apply on
+this path (there is no page view to short-circuit).
+
+Sharing page-view context
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On the legacy path a handler implicitly inherits the page view's context
+(:code:`get_context_data`). On the router there is **no page view in the request
+cycle**, so that implicit context is gone. Two options:
+
+#. **Declare where the context comes from** with
+   :code:`shares_context_from = SomeView`. The endpoint stands that view up and
+   merges its context, reproducing the old behavior with one line:
+
+   .. code-block:: python
+
+       class EditWidgetHx(FormHxRequest):
+           name = "edit_widget"
+           GET_template = "widgets/_edit_form.html"
+           shares_context_from = WidgetListView  # its get_context_data() is merged in
+
+#. **Extract the shared context into a mixin** that both the page view and the
+   handler inherit — the cleaner long-term pattern, with no cross-view
+   instantiation.
+
+Two things to keep in mind on the router path:
+
+- A router handler must declare its own :code:`GET_template` / :code:`POST_template`.
+  There is no page-view :code:`template_name` to fall back to.
+- :code:`shares_context_from` fits context-only views such as
+  :code:`TemplateView` and :code:`ListView`. A :code:`DetailView` /
+  :code:`UpdateView` that needs a pk from the URL is out of scope for the
+  additive router — resolve the object through the signed token instead (it is
+  available as :code:`self.hx_object`).
+
+A handler with no :code:`shares_context_from` simply gets no page-view context;
+:code:`get_context_on_GET` / :code:`get_context_on_POST` and :code:`hx_object`
+still work as usual.

--- a/docs/superpowers/plans/2026-07-08-url-router.md
+++ b/docs/superpowers/plans/2026-07-08-url-router.md
@@ -1,0 +1,849 @@
+# URL Router (#10) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an additive `/hx/<name>/` URL router so named `HxRequest` handlers can be reached through real Django URLs (`reverse()`, URL decorators/middleware, per-endpoint caching, `show_urls`), without changing how a handler is declared.
+
+**Architecture:** The registry gains `get_urls()`, which turns each registered *name* into one `path()` bound to a thin `HxEndpointView`. The endpoint verifies the signed token, enforces **path binding** (token name must equal the URL name), then runs the existing `HxRequest.dispatch` — the same per-handler auth + get/post cycle the legacy page-view path uses. The two trust-boundary operations (token verify+sanitize, current-URL merge) are factored into module functions that both `HtmxViewMixin` (legacy) and `HxEndpointView` (router) call, so there is one trust boundary. The template tag prefers `reverse("hx:<name>")` and falls back to `request.path`, so the router is zero-config and additive.
+
+**Tech Stack:** Python 3.11+, Django 4.2+, pytest, `render_block`. Tests run with `.venv/bin/python -m pytest`; lint/format with `~/.local/bin/ruff` (`ruff check` **and** `ruff format --check`); commit with `--no-verify` (pre-commit is broken in this repo).
+
+## Global Constraints
+
+- **Additive only.** The legacy page-view dispatch (`HtmxViewMixin` query-param routing) must keep working unchanged. A project that does not wire the `include()` sees no behavior change. Removing the legacy path is a separate, later `feat!:`.
+- **Do not regress the three protected values:** many-handlers-one-registration (URLs are generated from the registry — users never hand-author a `path()` per handler), the form/modal round-trip, and composable trigger/confirm mixins. Plus plain-htmx fall-through (token-less HTMX still hits the page view).
+- **Lazy loading preserved.** `get_urls()` builds patterns from names only; it must not import handler classes.
+- **Namespace is the fixed string `hx`** (spec open-question #2 resolved to the documented default).
+- **One trust boundary.** Token verification/sanitization is shared code, not duplicated per path.
+- Python floor 3.11, Django floor 4.2. Use `from __future__ import annotations` and `X | None` unions (matches the existing files).
+- Commit messages end with the repo's trailer convention; use `feat:` (additive, non-breaking).
+
+## File structure
+
+- `hx_requests/views.py` — add module functions `bind_hx_token(request, expected_name=None)` and `merge_current_url(request)` (factored out of `HtmxViewMixin`), and the new `HxEndpointView`. `HtmxViewMixin` is rewired to call the shared functions.
+- `hx_requests/hx_registry.py` — add `HxRequestRegistry.get_urls()` (imports `HxEndpointView` lazily inside the method to avoid a circular import).
+- `hx_requests/hx_requests.py` — make `BaseHxRequest` tolerate `self.view is None` and add the `shares_context_from` class attribute.
+- `hx_requests/utils.py` — `get_url()` prefers `reverse("hx:<name>")` with a `NoReverseMatch` fallback.
+- `tests/urls.py` (new) — root URLconf wiring the router; `tests/settings.py` points `ROOT_URLCONF` at it.
+- `tests/helpers.py` — add `hx_get_url` / `hx_post_url` that drive real requests through `reverse()`-resolved router URLs via the Django test `Client`.
+- `tests/test_url_router.py` (new) — registry `get_urls`, resolution, path binding, auth parity, template-tag reverse/fallback, context sharing, fall-through, startup ordering.
+- `tests/test_app/hx_requests.py` — add a `shares_context_from` fixture handler.
+- `tests/test_app/views.py` — a plain `TemplateView` used as a `shares_context_from` source (no `HtmxViewMixin`).
+- `docs/` — new "Mounting HxRequests on URLs" how-to + a note on the securing/how-it-works pages.
+
+---
+
+### Task 1: `HxRequestRegistry.get_urls()`
+
+**Files:**
+- Modify: `hx_requests/hx_registry.py`
+- Test: `tests/test_url_router.py` (new)
+
+**Interfaces:**
+- Consumes: existing `HxRequestRegistry.initialize()` / `_registry` (name → class-or-tuple).
+- Produces: `HxRequestRegistry.get_urls() -> list[django.urls.URLPattern]`, one `path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name)` per registered name. Does **not** import handler classes. (`HxEndpointView` is created in Task 4; Task 1 imports it lazily inside the method, so the two tasks can land in either order but the test in Task 1 only passes once Task 4 exists — see Step 2.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+"""Tests for the additive /hx/<name>/ URL router (#10)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hx_requests.hx_registry import HxRequestRegistry
+
+
+def test_get_urls_returns_one_pattern_per_registered_name(clean_registry):
+    HxRequestRegistry.reset()
+    HxRequestRegistry.initialize()
+    urls = HxRequestRegistry.get_urls()
+
+    names = {pattern.name for pattern in urls}
+    assert "simple_get" in names
+    assert "other_app_hx" in names
+    assert "deep_hx" in names
+    assert len(urls) == len(HxRequestRegistry._registry)
+
+
+def test_get_urls_does_not_import_handler_classes(clean_registry):
+    HxRequestRegistry.reset()
+    HxRequestRegistry.get_urls()
+    # Building URLs must stay lazy: entries remain (module, class) tuples.
+    assert isinstance(HxRequestRegistry._registry["simple_get"], tuple)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -v`
+Expected: FAIL — `AttributeError: type object 'HxRequestRegistry' has no attribute 'get_urls'` (and, until Task 4 lands, an `ImportError` for `HxEndpointView`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `hx_requests/hx_registry.py` inside `HxRequestRegistry`:
+
+```python
+    @classmethod
+    def get_urls(cls):
+        """
+        Build one ``path()`` per registered handler name, routed to
+        :class:`~hx_requests.views.HxEndpointView`.
+
+        Wire it into a root URLconf once::
+
+            from hx_requests.hx_registry import HxRequestRegistry
+
+            urlpatterns = [
+                path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+            ]
+
+        Patterns are built from names only -- handler classes still import
+        lazily on first request -- so this is cheap and preserves lazy loading.
+        Patterns are a snapshot at URLconf-build time: adding a handler needs a
+        server restart, same as any URLconf change.
+        """
+        # Imported here, not at module scope: views.py imports this module, so a
+        # top-level import would be circular.
+        from hx_requests.views import HxEndpointView
+
+        cls.initialize()
+        return [
+            path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name)
+            for name in cls._registry
+        ]
+```
+
+Add `from django.urls import path` to the imports at the top of `hx_registry.py`.
+
+- [ ] **Step 4: Run test to verify it passes** (requires Task 4's `HxEndpointView`; if executing in order, land Task 4's view stub first or run this after Task 4)
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hx_requests/hx_registry.py tests/test_url_router.py
+git commit --no-verify -m "feat: build urlpatterns from the HxRequest registry"
+```
+
+---
+
+### Task 2: Factor the token trust boundary into shared functions
+
+**Files:**
+- Modify: `hx_requests/views.py`
+- Test: `tests/test_url_router.py`
+
+**Interfaces:**
+- Produces:
+  - `bind_hx_token(request, expected_name=None) -> HttpRequest` — verifies the signed `hx` token, rebuilds `request.GET` with only trusted framework data (drops client-supplied `hx`, `hx_request_name`, `object`, and `___`-prefixed kwargs; re-sets `hx_request_name`/`object` from the verified payload), stashes verified kwargs on `request._hx_kwargs`. Raises `Http404` on a missing/tampered token. When `expected_name` is given, the token's `name` must equal it (path binding) or `Http404` is raised.
+  - `merge_current_url(request) -> HttpRequest` — merges non-framework params from the `HX-Current-URL` header into `request.GET` (the existing `use_current_url` behavior).
+- Consumes: `HxEndpointView` (Task 4) and `HtmxViewMixin` (rewired here) both call these.
+
+This is a pure refactor: `HtmxViewMixin._resolve_hx_token` / `_use_current_url` become thin wrappers, so the existing suite must stay green.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+from django.http import Http404
+from django.test import RequestFactory
+
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
+from hx_requests.views import bind_hx_token
+
+
+def test_bind_hx_token_rejects_name_mismatch():
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
+    # A token minted for simple_get replayed against another endpoint 404s.
+    with pytest.raises(Http404):
+        bind_hx_token(request, expected_name="post_template")
+
+
+def test_bind_hx_token_accepts_matching_name():
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
+    bound = bind_hx_token(request, expected_name="simple_get")
+    assert bound.GET["hx_request_name"] == "simple_get"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py::test_bind_hx_token_rejects_name_mismatch tests/test_url_router.py::test_bind_hx_token_accepts_matching_name -v`
+Expected: FAIL — `ImportError: cannot import name 'bind_hx_token' from 'hx_requests.views'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `hx_requests/views.py`, add these module-level functions (after the imports, before `HtmxViewMixin`):
+
+```python
+def bind_hx_token(request, expected_name=None):
+    """
+    Verify the signed ``hx`` token and rebuild ``request.GET`` so the rest of
+    the chain reads *trusted* framework data. Everything the framework controls
+    (name, object, kwargs) comes from the signed token; any client-supplied
+    framework params on the raw query string are dropped so they cannot shadow
+    or forge the verified values. Non-framework params (page filters, runtime
+    hx-vals) are left untouched.
+
+    When ``expected_name`` is given (the router path, where the name comes from
+    the URL), the token's ``name`` must equal it -- a token minted for one
+    handler cannot be replayed against another endpoint. Raises ``Http404`` on a
+    missing/tampered token or a name mismatch.
+    """
+    if not request.GET.get(HX_TOKEN_PARAM):
+        logger.debug("hx_requests: denied (404) -- request carried no '%s' token.", HX_TOKEN_PARAM)
+        raise Http404("Missing required query param 'hx' for HTMX request.")
+    payload = get_hx_payload(request)
+    if payload is None:
+        logger.debug(
+            "hx_requests: denied (404) -- '%s' token was missing, tampered, or unsigned.",
+            HX_TOKEN_PARAM,
+        )
+        raise Http404("Invalid or tampered hx token.")
+    if expected_name is not None and payload["name"] != expected_name:
+        logger.debug(
+            "hx_requests: denied (404) -- token minted for '%s' replayed against '%s'.",
+            payload["name"],
+            expected_name,
+        )
+        raise Http404("hx token does not match this endpoint.")
+
+    sanitized = request.GET.copy()
+    for key in list(sanitized.keys()):
+        if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+            del sanitized[key]
+    sanitized["hx_request_name"] = payload["name"]
+    if payload.get("object"):
+        sanitized["object"] = payload["object"]
+
+    request.GET = sanitized
+    # Verified, serialized kwargs from the token -- the only source of
+    # kwargs-as-context. Raw query params never feed this again.
+    request._hx_kwargs = payload.get("kwargs", {})
+    return request
+
+
+def merge_current_url(request):
+    """
+    Merge non-framework params from the ``HX-Current-URL`` header into
+    ``request.GET`` (the ``use_current_url`` behavior). Framework params
+    (name/object/kwargs/token) are never merged from the current URL: those are
+    trusted only via the signed token, not raw query input.
+    """
+    merged_get = request.GET.copy()
+    hx_current_url = request.headers.get("HX-Current-URL")
+    if hx_current_url:
+        parsed_url = urlparse(hx_current_url)
+        additional_params = parse_qs(parsed_url.query)
+        for key, values in additional_params.items():
+            if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+                continue
+            if key not in merged_get:
+                merged_get.setlist(key, values)
+    request.GET = merged_get
+    return request
+```
+
+Then rewire `HtmxViewMixin` to delegate (replace the bodies of `_resolve_hx_token` and `_use_current_url`):
+
+```python
+    def _resolve_hx_token(self, request):
+        return bind_hx_token(request)
+
+    def _use_current_url(self, request):
+        return merge_current_url(request)
+```
+
+- [ ] **Step 4: Run test to verify it passes (and the full suite stays green)**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py tests/test_security.py tests/test_base_hx_request.py -v`
+Expected: PASS (new token tests pass; the refactor leaves legacy behavior identical).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hx_requests/views.py tests/test_url_router.py
+git commit --no-verify -m "refactor: share the token trust boundary between legacy and router paths"
+```
+
+---
+
+### Task 3: Make `BaseHxRequest` tolerate `view = None` + add `shares_context_from`
+
+**Files:**
+- Modify: `hx_requests/hx_requests.py`
+- Test: `tests/test_url_router.py`
+
+**Interfaces:**
+- Produces: `BaseHxRequest.shares_context_from: type | None = None` class attribute; `BaseHxRequest` works when `self.view is None` (no page-view context harvested, template falls back to `None` so an explicit `GET_template`/`POST_template` is required).
+- Consumes: `HxEndpointView` (Task 4) sets `hx_request.view = None` or an instantiated `shares_context_from` view.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+from hx_requests.hx_requests import BaseHxRequest
+
+
+def test_base_hx_request_sets_up_with_no_view():
+    class NoViewHx(BaseHxRequest):
+        name = "no_view_hx_unit"
+        GET_template = "simple.html"
+
+    hx = NoViewHx()
+    hx.view = None
+    request = RequestFactory().get("/")
+    request.user = None
+    # Must not raise despite there being no page view to harvest context from.
+    hx._setup_hx_request(request)
+    assert hx.GET_template == "simple.html"
+    context = hx.get_context_data()
+    assert context["hx_request"] is hx
+
+
+def test_shares_context_from_defaults_to_none():
+    assert BaseHxRequest.shares_context_from is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py::test_base_hx_request_sets_up_with_no_view tests/test_url_router.py::test_shares_context_from_defaults_to_none -v`
+Expected: FAIL — `AttributeError: 'NoneType' object has no attribute 'template_name'` (in `_setup_hx_request`) and `AttributeError: ... 'shares_context_from'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `hx_requests/hx_requests.py`:
+
+1. Add the class attribute near `model` (around line 90):
+
+```python
+    #: Optional Django view class to harvest page-view context from on the
+    #: router path (there is no page view in the request cycle there). When set,
+    #: the endpoint instantiates it, runs ``setup()``, and assigns it as the
+    #: context source -- reproducing the legacy implicit-context behavior with a
+    #: one-line declaration. Leave unset (the explicit, non-surprising default)
+    #: and a router handler simply gets no page-view context;
+    #: ``get_context_on_GET`` / ``get_context_on_POST`` / ``hx_object`` still work.
+    shares_context_from = None
+```
+
+2. In `_setup_hx_request`, replace the template fallback and eager-harvest lines:
+
+```python
+        view_template = getattr(self.view, "template_name", None)
+        self.GET_template = self.GET_template or view_template
+        self.POST_template = self.POST_template or view_template
+
+        if not hasattr(self, "hx_object"):
+            self.hx_object = self.get_hx_object(request, **kwargs)
+
+        # Harvest the page view's context up front when it will be rendered, so
+        # that on POST it reflects state captured before post() mutates anything
+        # (the documented stale-context behavior). When the POST renders nothing
+        # from the view, the harvest -- and the page view's query cost -- is
+        # skipped entirely. With no page view (router path) there is nothing to
+        # harvest.
+        if self.view is not None and self.get_views_context and self._renders_view_context():
+            _ = self.view_response
+```
+
+3. In `get_context_data`, guard the harvest:
+
+```python
+        if self.view is not None and self.get_views_context and hasattr(self.view_response, "context_data"):
+            context.update(self.view_response.context_data)
+```
+
+4. In `get_context_on_POST`, guard the refresh block:
+
+```python
+        if self.refresh_views_context_on_POST and self.view is not None:
+            if hasattr(self.view, "object") and self.view.object:
+                self.view.object.refresh_from_db()
+                context["object"] = self.view.object
+            context.update(self.view.get_context_data(**kwargs))
+```
+
+- [ ] **Step 4: Run test to verify it passes (and the legacy suite stays green)**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py tests/test_base_hx_request.py tests/test_lazy_context.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hx_requests/hx_requests.py tests/test_url_router.py
+git commit --no-verify -m "feat: let BaseHxRequest run without a page view (router path)"
+```
+
+---
+
+### Task 4: `HxEndpointView` — the router request cycle
+
+**Files:**
+- Modify: `hx_requests/views.py`
+- Test: `tests/test_url_router.py`, `tests/urls.py` (new), `tests/settings.py`, `tests/helpers.py`
+
+**Interfaces:**
+- Consumes: `bind_hx_token` / `merge_current_url` (Task 2), `HxRequestRegistry.get_hx_request` / `get_urls` (Task 1), `BaseHxRequest` view=None support + `shares_context_from` (Task 3).
+- Produces: `HxEndpointView(View)` with class attribute `hx_name = None`, set per-path via `as_view(hx_name=...)`. Its `dispatch` resolves the handler, binds the token with path binding, wires the context view, and delegates to `hx_request.dispatch`. Test helpers `hx_get_url(client, hx_request, ...)` / `hx_post_url(client, hx_request, ...)` drive real requests through `reverse("hx:<name>")`.
+
+- [ ] **Step 1: Wire a test URLconf and helpers (scaffolding for this task's test)**
+
+Create `tests/urls.py`:
+
+```python
+"""Root URLconf for the test suite: mounts the additive HxRequest router."""
+
+from django.urls import include, path
+
+from hx_requests.hx_registry import HxRequestRegistry
+
+urlpatterns = [
+    path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+]
+```
+
+In `tests/settings.py`, change `ROOT_URLCONF = None` to:
+
+```python
+ROOT_URLCONF = "urls"
+```
+
+Add to `tests/helpers.py`:
+
+```python
+from django.urls import reverse
+
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload  # (already imported; keep one import)
+
+
+def _router_query(hx_request, hx_kwargs=None, get_params=None):
+    hx_kwargs = dict(hx_kwargs or {})
+    get_params = dict(get_params or {})
+    hx_object = hx_kwargs.pop("object", None)
+    query = {HX_TOKEN_PARAM: sign_hx_payload(hx_request.name, hx_object, **hx_kwargs)}
+    query.update(get_params)
+    return query
+
+
+def hx_get_url(client, hx_request, hx_kwargs=None, get_params=None):
+    """Drive a GET through the router URL (reverse('hx:<name>'))."""
+    url = reverse(f"hx:{hx_request.name}")
+    return client.get(url, data=_router_query(hx_request, hx_kwargs, get_params), HTTP_HX_REQUEST="true")
+
+
+def hx_post_url(client, hx_request, hx_kwargs=None, get_params=None, post_data=None):
+    """Drive a POST through the router URL (reverse('hx:<name>'))."""
+    url = reverse(f"hx:{hx_request.name}")
+    query = _router_query(hx_request, hx_kwargs, get_params)
+    return client.post(
+        f"{url}?{urlencode(query)}", data=post_data or {}, HTTP_HX_REQUEST="true"
+    )
+```
+
+Add `from urllib.parse import urlencode` to the top of `tests/helpers.py`.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+from django.test import Client
+
+
+@pytest.fixture()
+def hx_client(db, django_user_model):
+    """A logged-in test client (handlers default to login_required=True)."""
+    user = django_user_model.objects.create_user(username="router", password="pw")
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+def test_router_dispatches_get_to_handler(hx_client, clean_registry):
+    from tests.helpers import hx_get_url
+    from test_app.hx_requests import SimpleGetHx
+
+    response = hx_get_url(hx_client, SimpleGetHx)
+    assert response.status_code == 200
+    assert b"simple" in response.content.lower()
+
+
+def test_router_path_binding_rejects_replayed_token(hx_client, clean_registry):
+    from django.urls import reverse
+    from test_app.hx_requests import SimpleGetHx
+    from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
+
+    # Token minted for simple_get, sent to post_template's URL -> 404.
+    url = reverse("hx:post_template")
+    token = sign_hx_payload(SimpleGetHx.name)
+    response = hx_client.get(url, data={HX_TOKEN_PARAM: token}, HTTP_HX_REQUEST="true")
+    assert response.status_code == 404
+
+
+def test_router_missing_token_404s(hx_client, clean_registry):
+    from django.urls import reverse
+
+    response = hx_client.get(reverse("hx:simple_get"), HTTP_HX_REQUEST="true")
+    assert response.status_code == 404
+
+
+def test_router_enforces_per_handler_auth(db, clean_registry):
+    from test_app.hx_requests import SimpleGetHx
+    from tests.helpers import hx_get_url
+
+    # Anonymous client + login_required default -> 404 (bodiless).
+    anon = Client()
+    response = hx_get_url(anon, SimpleGetHx)
+    assert response.status_code == 404
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -k router -v`
+Expected: FAIL — `ImportError: cannot import name 'HxEndpointView'` / `NoReverseMatch`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+In `hx_requests/views.py`:
+
+1. Add imports at the top:
+
+```python
+from django.views import View
+```
+
+2. Update the `deserialize_kwargs` import line (it is already imported from `hx_requests.utils` — confirm `deserialize_kwargs` and `KWARG_PREFIX` are in that import list; they are).
+
+3. Add the endpoint (after `HtmxViewMixin`):
+
+```python
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class HxEndpointView(View):
+    """
+    The router request cycle for one named ``HxRequest``.
+
+    Mounted at ``/hx/<name>/`` by :meth:`HxRequestRegistry.get_urls`. Because the
+    handler name comes from the URL path (not a client query param), a token
+    minted for one handler cannot be replayed against another endpoint -- the
+    endpoint asserts ``token.name == url.name`` (path binding). Per-handler
+    authorization is unchanged: it runs inside ``HxRequest.dispatch`` before
+    ``get`` / ``post``. Because this is a real Django ``View``, Django's own
+    ``login_required`` / ``LoginRequiredMixin`` compose natively on this path.
+    """
+
+    hx_name = None  # set per-path by as_view(hx_name=...)
+
+    def dispatch(self, request, *args, **kwargs):
+        hx_cls = HxRequestRegistry.get_hx_request(self.hx_name)
+        if hx_cls is None:
+            logger.debug(
+                "hx_requests: denied (404) -- no HxRequest registered under the name '%s'.",
+                self.hx_name,
+            )
+            raise Http404(f"No HxRequest found with the name '{self.hx_name}'.")
+
+        request = bind_hx_token(request, expected_name=self.hx_name)
+        kwargs.update(deserialize_kwargs(**getattr(request, "_hx_kwargs", {})))
+
+        hx_request = hx_cls()
+
+        # No page view in the router cycle. A handler opts back into page-view
+        # context with `shares_context_from = SomeView`; the endpoint stands that
+        # view up and assigns it as the context source (the same `view` seam the
+        # legacy path uses), so BaseHxRequest harvests it unchanged.
+        context_view_cls = getattr(hx_cls, "shares_context_from", None)
+        if context_view_cls is not None:
+            context_view = context_view_cls()
+            context_view.setup(request, *args, **kwargs)
+            hx_request.view = context_view
+        else:
+            hx_request.view = None
+
+        if getattr(hx_request, "use_current_url", False):
+            request = merge_current_url(request)
+
+        hx_request._setup_hx_request(request, *args, **kwargs)
+        return hx_request.dispatch(hx_request.request, *args, **kwargs)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Run the FULL suite (ROOT_URLCONF change is global — nothing else may break)**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: all pass. If a pre-existing test broke on the `ROOT_URLCONF` change, fix the test wiring (not the router).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add hx_requests/views.py tests/urls.py tests/settings.py tests/helpers.py tests/test_url_router.py
+git commit --no-verify -m "feat: add HxEndpointView router endpoint with path binding"
+```
+
+---
+
+### Task 5: Template tag `get_url()` prefers `reverse()`
+
+**Files:**
+- Modify: `hx_requests/utils.py`
+- Test: `tests/test_url_router.py`
+
+**Interfaces:**
+- Consumes: `reverse` / `NoReverseMatch` from `django.urls`.
+- Produces: `get_url()` returns `reverse("hx:<name>")?hx=<token>` when the router is installed, else `request.path?hx=<token>` (legacy). Signature unchanged. The signed token still carries name/object/kwargs, so signing composes unchanged and loose page-filter params behave as today.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+from django.template import Context, Template
+
+
+def _render(template_str, context):
+    return Template("{% load hx_tags %}" + template_str).render(Context(context))
+
+
+def test_get_url_uses_reverse_when_router_installed(rf, clean_registry):
+    from hx_requests.utils import get_url
+
+    request = rf.get("/some/page/")
+    url = get_url({"request": request}, "simple_get", None)
+    # Router installed (tests/urls.py) -> reversed router URL, not request.path.
+    assert url.startswith("/hx/simple_get/?")
+    assert "hx=" in url
+
+
+def test_get_url_falls_back_to_request_path_for_unknown_name(rf, clean_registry):
+    from hx_requests.utils import get_url
+
+    request = rf.get("/some/page/")
+    url = get_url({"request": request}, "not_a_registered_router_name", None)
+    assert url.startswith("/some/page/?")
+```
+
+Note: `not_a_registered_router_name` has no `path()` so `reverse()` raises `NoReverseMatch`, exercising the fallback. (`rf` is pytest-django's `RequestFactory` fixture.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -k get_url -v`
+Expected: FAIL — the current `get_url` always returns `request.path`, so the first test fails on the `/hx/simple_get/` assertion.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `hx_requests/utils.py`, add the import:
+
+```python
+from django.urls import NoReverseMatch, reverse
+```
+
+Replace the final `return` of `get_url`:
+
+```python
+    params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, **kwargs)
+
+    # Prefer the router URL when it is installed; fall back to the current path
+    # (legacy page-view dispatch) so a project that has not wired the router
+    # keeps working with no template edits.
+    try:
+        base = reverse(f"hx:{hx_request_name}")
+    except NoReverseMatch:
+        base = request.path
+
+    return f"{base}?{urlencode(params, doseq=True)}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -k get_url tests/test_hx_tags.py -v`
+Expected: PASS (router tests pass; existing `test_hx_tags.py` still passes — those requests resolve names the router doesn't register, or assert on the `hx=` token which is unchanged. If a tag test now sees `/hx/<name>/` where it asserted `request.path`, update that assertion to accept the reversed URL — the token is what matters.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add hx_requests/utils.py tests/test_url_router.py
+git commit --no-verify -m "feat: template tags emit reverse() router URLs with a legacy fallback"
+```
+
+---
+
+### Task 6: `shares_context_from` end-to-end + plain-htmx fall-through + startup ordering
+
+**Files:**
+- Modify: `tests/test_app/hx_requests.py`, `tests/test_app/views.py`
+- Test: `tests/test_url_router.py`
+
+**Interfaces:**
+- Consumes: `HxEndpointView` (Task 4), `shares_context_from` (Task 3), the router (Task 1).
+- Produces: a fixture handler `SharesContextHx` (`shares_context_from = RouterContextView`) proving page-view context is reproduced on the router path; tests that a handler without it gets no page-view context; a fall-through test; a startup-ordering test.
+
+- [ ] **Step 1: Add fixtures**
+
+In `tests/test_app/views.py`, add a plain view (no `HtmxViewMixin` — it is only a context source):
+
+```python
+class RouterContextView(TemplateView):
+    template_name = "base_view.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["view_flavor"] = "from-the-view"
+        return context
+```
+
+In `tests/test_app/hx_requests.py`, add the import near the existing `from test_app.forms import WidgetForm` line, then the handler (there is no import cycle: `test_app/views.py` imports from `hx_requests.views`, not from `test_app.hx_requests`):
+
+```python
+from test_app.views import RouterContextView
+
+
+class SharesContextHx(BaseHxRequest):
+    name = "shares_context"
+    GET_template = "view_flavor.html"
+    shares_context_from = RouterContextView
+```
+
+The registry discovers it by its string `name` via AST without importing the module; the import runs lazily on first request.
+
+Create `tests/templates/view_flavor.html`:
+
+```html
+<div>{{ view_flavor|default:"no-view-context" }}</div>
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/test_url_router.py`:
+
+```python
+def test_shares_context_from_reproduces_view_context(hx_client, clean_registry):
+    from tests.helpers import hx_get_url
+    from test_app.hx_requests import SharesContextHx
+
+    response = hx_get_url(hx_client, SharesContextHx)
+    assert response.status_code == 200
+    assert b"from-the-view" in response.content
+
+
+def test_no_shares_context_gets_no_view_context(hx_client, clean_registry):
+    from django.urls import reverse
+    from hx_requests.utils import sign_hx_payload, HX_TOKEN_PARAM
+
+    # simple_get has no shares_context_from; view context is simply absent.
+    # (It renders fine because it declares its own GET_template.)
+    response = hx_client.get(
+        reverse("hx:simple_get"),
+        data={HX_TOKEN_PARAM: sign_hx_payload("simple_get")},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+
+
+def test_plain_htmx_without_token_is_not_a_router_request():
+    # A token-less HTMX request carries no signed payload, so it is not an
+    # hx-requests request -- the page view (legacy path) handles it. The router
+    # only mounts named handlers; it never intercepts token-less htmx.
+    from hx_requests.utils import is_hx_request
+
+    request = RequestFactory().get("/", HTTP_HX_REQUEST="true")
+    assert is_hx_request(request) is False
+
+
+def test_urlconf_builds_without_touching_the_registry(clean_registry):
+    # Importing the URLconf must build patterns without error even if the
+    # registry was reset (initialize() runs inside get_urls()).
+    HxRequestRegistry.reset()
+    urls = HxRequestRegistry.get_urls()
+    assert any(p.name == "simple_get" for p in urls)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -k "shares_context or plain_htmx or urlconf_builds" -v`
+Expected: FAIL — `shares_context` handler / `view_flavor.html` not yet present (or context assertion fails).
+
+- [ ] **Step 4: Implement (fixtures from Step 1) and re-run**
+
+Run: `.venv/bin/python -m pytest tests/test_url_router.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_app/hx_requests.py tests/test_app/views.py tests/templates/view_flavor.html tests/test_url_router.py
+git commit --no-verify -m "test: cover shares_context_from, fall-through, and startup ordering"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Create: `docs/` how-to page "Mounting HxRequests on URLs".
+- Modify: the securing / how-it-works pages to note Django auth composes natively on the router path.
+
+**Interfaces:** none (docs only). Locate the docs layout first: `ls docs/` and follow the existing `.rst`/`.md` convention and toctree.
+
+- [ ] **Step 1: Inspect docs layout**
+
+Run: `ls docs/ && find docs -name "*.rst" -o -name "index.*" | head`
+Read the toctree/index to learn where a new how-to is registered.
+
+- [ ] **Step 2: Write the how-to** (match the existing file format — `.rst` if the others are)
+
+Cover, with runnable snippets:
+- Wiring the router once in the root URLconf:
+  ```python
+  from hx_requests.hx_registry import HxRequestRegistry
+  urlpatterns = [
+      path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+  ]
+  ```
+- That it is additive/zero-config: templates need no edits (`hx_get`/`hx_post` emit `reverse("hx:<name>")` automatically, falling back to the current path when the router is not installed).
+- `reverse("hx:<name>")` now works for hand-built URLs.
+- Path binding: a token is bound to its handler's URL and cannot be replayed against another endpoint.
+- `shares_context_from = SomeView` to reproduce page-view context on the router path, and the shared-context mixin as the cleaner long-term pattern. Note a router handler must declare its own `GET_template`/`POST_template` (there is no page-view template to fall back to), and that `shares_context_from` best fits `TemplateView`/`ListView` (a `DetailView`/`UpdateView` needing a URL pk is out of scope for the additive router — use `hx_object` from the token instead).
+- That adding a handler needs a server restart (URLconf snapshot).
+
+- [ ] **Step 3: Note native Django auth on the securing / how-it-works pages**
+
+Add a short paragraph: on the router path the endpoint is a real Django `View`, so `login_required` / `LoginRequiredMixin` compose natively and the `hx_requests.W001` MRO trap does not apply (it remains relevant only for the legacy page-view path). Per-handler auth (`login_required` / `permission_required` / `has_permission`) works identically on both paths.
+
+- [ ] **Step 4: Validate RST (if applicable) and commit**
+
+If docs are `.rst`, validate with docutils as in prior PRs:
+Run: `.venv/bin/pip install docutils >/dev/null 2>&1; .venv/bin/python -c "from docutils.core import publish_doctree; publish_doctree(open('docs/<newfile>.rst').read())"` (sphinx-only role warnings are fine).
+
+```bash
+git add docs/
+git commit --no-verify -m "docs: how-to for mounting HxRequests on URLs (#10)"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full suite: `.venv/bin/python -m pytest -q` — all green.
+- [ ] Lint: `~/.local/bin/ruff check hx_requests tests && ~/.local/bin/ruff format --check hx_requests tests` — clean (run `ruff format` to fix wrapping; pre-commit's ruff-format hook is what CI-adjacent checks use).
+- [ ] Update `IMPROVEMENTS.md`: mark #10's status. Note this branch does not carry #202's GET-write guard (sibling branch); the guard composes automatically on the router path once #202 is in the base, because it lives in `HxRequest.dispatch`. Add a `test_get_writes`-style router assertion when this branch is rebased onto a base that includes #202.
+- [ ] Update `PR #203` body: it currently says "Plan/spec only — no implementation." Change it to describe the implemented router (or confirm with the user whether the implementation should live on #203's `docs/url-router-spec` branch or a fresh `feat/url-router` branch stacked after #202).
+
+## Open questions resolved (from the spec), for the record
+
+1. **Legacy dispatch:** additive now; a later `feat!:` removes query-param dispatch. (Spec's recommendation.)
+2. **Namespace:** fixed `hx:`. (Spec's assumption.)
+3. **`get_urls()` timing:** `initialize()` at URLconf-build time; patterns are a snapshot; adding a handler needs a restart (documented).
+4. **`shares_context_from` per-view-type preamble:** resolved by *reusing the existing `view` harvest seam* (assign the instantiated view to `hx_request.view`) rather than resurrecting `django_views.py`'s per-view-type setup. This reproduces today's behavior with near-zero new code (YAGNI); `TemplateView`/`ListView` are supported, pk-bound `DetailView`/`UpdateView` are explicitly out of scope for the additive step (use `hx_object`). This is a deliberate resolution of the spec's open question #4, not a contradiction of an approved decision — flag it for the user.

--- a/docs/superpowers/specs/2026-07-07-url-router-design.md
+++ b/docs/superpowers/specs/2026-07-07-url-router-design.md
@@ -1,0 +1,247 @@
+# Design: Mount HxRequests on real URLs (#10, the URL router)
+
+Status: **draft for review** — no implementation until approved. This is the
+plan for `IMPROVEMENTS.md` item #10.
+
+## What this is (and is not)
+
+This plans the **additive URL router**: generate real `/hx/<name>/` URLs from
+the registry and route named handlers through them, so `reverse()`, URL-level
+decorators/middleware, per-endpoint caching, and `show_urls` all start working.
+
+It is **deliberately scoped as step 1 of the "real Django views" arc** (the
+IMPROVEMENTS.md appendix), not that rewrite. The rewrite (rebuild the base
+classes mixin-first on `View` + `SingleObjectMixin` + `FormMixin`, change the
+`form_valid` signature) is a separate 1.0 effort with a long-lived-branch risk
+the appendix itself flags. Two reasons to do the router first instead of folding
+it in:
+
+- **It ships in the reviewable, stacked style that has worked for #1–#9.** The
+  rewrite does not.
+- **#9 already banked half the rewrite's payoff.** Per-handler auth
+  (`login_required` / `permission_required` / `has_permission`) is done. The
+  rewrite's headline "deletes #3 and most of #9" would now partly *re-do* work we
+  just shipped. Better to treat the rewrite as a deliberate later step.
+
+The router is only worth doing if it **moves dispatch onto the URLs** rather than
+adding a parallel path that the rewrite later rips out. That is the design below:
+the endpoint becomes the real request cycle for a named handler; the page-view
+handoff (`HtmxViewMixin`) stays only for backward compatibility during migration.
+
+### Non-goals (YAGNI / explicitly out of scope)
+
+- No `form_valid(self, form)` signature change — that is the rewrite.
+- Do **not** delete per-handler auth, the registry, or the base-class hierarchy.
+- No subclassing of Django generic views (`FormView`, `UpdateView`) — the
+  appendix explains why that fights the framework at every override.
+
+## The value that must survive (do not regress)
+
+From IMPROVEMENTS.md's "genuinely good at" section — the router must preserve all
+three:
+
+1. **Many handlers, one registration.** Declaring a handler stays "add a class
+   with a `name`." URLs are *generated from the registry*; users never
+   hand-author a `path()` per handler.
+2. **The form/modal round-trip.** Untouched — it lives in the response mixins,
+   which the router does not change.
+3. **Composable trigger/confirm mixins.** Untouched — they touch
+   triggers/headers/`post`, not routing.
+
+Plus the **plain-htmx fall-through** (sort/filter/paginate requests that omit a
+handler name and hit the underlying page view) must keep working.
+
+## Architecture
+
+### 1. Registry → urlpatterns
+
+Add `HxRequestRegistry.get_urls()`. It calls `initialize()` (the existing AST
+scan, which yields *names* without importing handler classes — lazy loading is
+preserved) and returns one `path()` per registered name:
+
+```python
+# hx_registry.py
+@classmethod
+def get_urls(cls):
+    cls.initialize()
+    return [
+        path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name)
+        for name in cls._registry
+    ]
+```
+
+Users wire it once, in their root URLconf:
+
+```python
+from hx_requests.hx_registry import HxRequestRegistry
+
+urlpatterns = [
+    path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+]
+```
+
+`reverse("hx:edit_user")` → `/hx/edit_user/`. Only handler *names* are needed to
+build the patterns; the handler class still imports lazily on first request via
+`get_hx_request(name)`.
+
+**Startup-ordering caveat (must test).** The root URLconf is built after
+`apps.populate()`, so the app registry is populated when `get_urls()` runs. But
+`get_urls()` calls `initialize()` (an AST filesystem scan) at URLconf-build time.
+Confirm this is safe and cheap, and that a later hot-reload / test `reset()` does
+not leave stale patterns. Patterns are a snapshot at URLconf build; document that
+adding a handler needs a server restart (same as any URLconf change).
+
+### 2. `HxEndpointView` — the new request cycle
+
+A thin Django `View` that becomes the real endpoint for one named handler:
+
+```python
+class HxEndpointView(View):
+    hx_name = None  # set per-path by as_view(hx_name=...)
+
+    def dispatch(self, request, *args, **kwargs):
+        hx_cls = HxRequestRegistry.get_hx_request(self.hx_name)
+        if hx_cls is None:
+            raise Http404(...)
+        payload = self._verify_token(request)          # reuse today's token logic
+        if payload["name"] != self.hx_name:            # path binding (see below)
+            raise Http404(...)
+        hx_request = hx_cls()
+        hx_request.view = None                          # no page view here (see §3)
+        hx_request._setup_hx_request(request, *args, **kwargs)
+        return hx_request.dispatch(hx_request.request, *args, **kwargs)
+```
+
+Key points:
+
+- **The handler name comes from the URL path, not a client query param.** This
+  closes the security-review "Path binding" note: a token minted for `edit_user`
+  can no longer be replayed against `delete_user`'s endpoint — the endpoint checks
+  `payload["name"] == self.hx_name` and 404s on mismatch. (Cheaper and clearer
+  than the per-name-salt alternative from that note.)
+- **Per-handler auth is unchanged** — `HxRequest.dispatch` still runs
+  `check_permissions` before `get`/`post`. It works identically here.
+- **Django auth now composes natively.** Because the endpoint is a real `View`,
+  `login_required` decorators / `LoginRequiredMixin` can wrap it, and the
+  `hx_requests.W001` MRO trap simply does not exist on this path (there is no
+  page-view handoff to short-circuit). W001 stays for the legacy page-view path.
+
+The token-verification and GET-sanitizing logic currently in
+`HtmxViewMixin._resolve_hx_token` / `get_hx_extra_kwargs` is factored into a
+shared helper both `HtmxViewMixin` (legacy) and `HxEndpointView` call, so there is
+one trust boundary, not two.
+
+### 3. Context sharing — the one real cost
+
+With a handler on its own URL there is **no page view in the cycle**, so today's
+implicit `view.get().context_data` harvest cannot happen. Decision (matches the
+appendix's recommended migration path and #4's explicit-opt-in direction):
+
+- **`shares_context_from = SomeView`** (opt-in class attribute). When set, the
+  endpoint instantiates that view, runs `view.setup(request, ...)`, the
+  type-specific `object` / `object_list` preamble, and `get_context_data()`, and
+  merges the result — reproducing today's behavior with a one-line declaration.
+  The dead `django_views.py` removed in #8a was a half-built version of exactly
+  these per-view-type setup helpers; resurrect that shape here.
+- **Document the shared-context mixin as the cleaner long-term pattern** (extract
+  shared context into a mixin both the page view and the handler inherit — no
+  cross-view instantiation).
+
+Handlers with no `shares_context_from` simply get no page-view context on the
+router path — which is the explicit, non-surprising behavior #4 was steering
+toward. `get_context_on_GET` / `get_context_on_POST` / `hx_object` still work.
+
+### 4. Template tags call `reverse()` — additively
+
+`get_url()` (utils.py) changes from `f"{request.path}?{token}"` to preferring the
+router, with a zero-config fallback:
+
+```python
+try:
+    base = reverse(f"hx:{hx_request_name}")   # router installed
+except NoReverseMatch:
+    base = request.path                        # legacy page-view dispatch
+```
+
+So a project that has not wired the router keeps working unchanged; a project that
+has gets real URLs with no template edits. The signed `hx` token rides on the
+query string exactly as today (`/hx/edit_user/?hx=...`), so signing (#1) composes
+unchanged. `use_current_url` and loose page-filter params behave as they do now.
+
+### 5. Plain-htmx fall-through
+
+Unaffected. The router only mounts *named* handlers. Token-less HTMX requests
+(sort/filter/paginate that the user wires with their own `hx-get` on a table) still
+hit the page view, which still exists and still handles them. Nothing about that
+path moves.
+
+## Data flow (router path)
+
+```
+browser  --GET /hx/edit_user/?hx=<token>-->  HxEndpointView(hx_name="edit_user")
+  -> get_hx_request("edit_user")                  # lazy import, cached
+  -> verify token; assert payload.name == "edit_user"
+  -> HxRequest()._setup_hx_request(request)        # object resolution via get_queryset (#2)
+  -> HxRequest.dispatch()                          # check_permissions (#9), GET-write guard (#202)
+  -> get()/post() -> Renderer -> HTMX partial
+```
+
+## Error handling
+
+- Unknown name / unregistered: `Http404` (as today, with the #8c debug log line).
+- Missing / tampered / unsigned token: `Http404` (reuse `get_hx_payload`).
+- Token name ≠ URL name: `Http404` (new — the path-binding check).
+- Auth: `Http404` (anon) / `PermissionDenied` (authed, no perm) — unchanged, from
+  per-handler auth.
+- `HttpResponseNotAllowed` for an unsupported method — unchanged.
+
+## Testing strategy
+
+- **Registry:** `get_urls()` returns one pattern per registered name and does
+  **not** import handler classes (assert entries stay tuples / lazy).
+- **Resolution:** `reverse("hx:<name>")` resolves; the URL dispatches to the right
+  handler.
+- **Path binding:** a token minted for handler A, sent to handler B's URL, 404s.
+- **Auth parity:** re-run the per-handler-auth scenarios (login/permission/
+  has_permission) through the new URL — same 404/403/200 outcomes.
+- **GET-write guard (#202):** still fires on the router path.
+- **Template tag:** emits a `reverse()` URL when the router is installed; falls
+  back to `request.path` (with `hx_request_name` for legacy dispatch) when it is
+  not.
+- **Context sharing:** `shares_context_from` reproduces the declared view's
+  context; absent it, the handler gets no page-view context (explicit).
+- **Fall-through:** a token-less HTMX request still hits the page view.
+- **Startup ordering:** importing the URLconf builds patterns without error when
+  the registry has not been touched yet.
+
+Tests drive real requests through `reverse()`-resolved URLs (extend
+`tests/helpers.py` with an `hx_get_url` / `hx_post_url` that go through the router)
+rather than hand-instantiating handlers.
+
+## Shipping
+
+Additive: the router and the legacy page-view dispatch coexist, so existing
+projects are untouched until they wire the `include()`. The endgame — per the #1
+clean-break rationale and the user's stated dislike of long-lived deprecation
+shims — is a later `feat!:` that makes the router the only path and removes
+`HtmxViewMixin`'s query-param dispatch. This spec ships the additive introduction;
+the removal is a separate, later decision.
+
+Docs: new "Mounting HxRequests on URLs" how-to (wiring the `include`, `reverse`
+usage, `shares_context_from`), and an update to the securing/how-it-works pages
+noting Django auth composes natively on the router path.
+
+## Open questions (resolve before/while writing the implementation plan)
+
+1. **Legacy dispatch: deprecation window vs. clean break.** Ship additive now and
+   remove query-param dispatch in a later `feat!:` (recommended), or break in this
+   PR? The user dislikes shims, which argues for a nearer clean break — but the
+   router forces the `shares_context_from` migration, which argues for a window.
+2. **Namespace.** Fixed `hx:` namespace (assumed above) vs. configurable, for
+   projects that mount the router more than once or want a custom prefix.
+3. **`get_urls()` timing.** Confirm calling `initialize()` at URLconf-build time is
+   acceptable, or whether patterns should be built lazily on first resolve.
+4. **`shares_context_from` for `object`/`object_list` views.** How much per-view-
+   type preamble to resurrect from `django_views.py` — `ListView` and
+   `DetailView` need `object_list` / `object` set before `get_context_data()`.
+```

--- a/hx_requests/hx_registry.py
+++ b/hx_requests/hx_registry.py
@@ -244,8 +244,7 @@ class HxRequestRegistry:
 
         cls.initialize()
         return [
-            path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name)
-            for name in cls._registry
+            path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name) for name in cls._registry
         ]
 
     @classmethod

--- a/hx_requests/hx_registry.py
+++ b/hx_requests/hx_registry.py
@@ -22,6 +22,7 @@ import os
 import threading
 
 from django.apps import apps
+from django.urls import path
 
 from hx_requests.hx_requests import BaseHxRequest
 
@@ -217,6 +218,35 @@ class HxRequestRegistry:
         # By now, any entries that failed to import or failed subclass check
         # may still be tuples. Filter them out to match typical expectation.
         return {k: v for k, v in cls._registry.items() if isinstance(v, type)}
+
+    @classmethod
+    def get_urls(cls):
+        """
+        Build one ``path()`` per registered handler name, routed to
+        :class:`~hx_requests.views.HxEndpointView`.
+
+        Wire it into a root URLconf once::
+
+            from hx_requests.hx_registry import HxRequestRegistry
+
+            urlpatterns = [
+                path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+            ]
+
+        Patterns are built from names only -- handler classes still import
+        lazily on first request -- so this is cheap and preserves lazy loading.
+        Patterns are a snapshot at URLconf-build time: adding a handler needs a
+        server restart, same as any URLconf change.
+        """
+        # Imported here, not at module scope: views.py imports this module, so a
+        # top-level import would be circular.
+        from hx_requests.views import HxEndpointView
+
+        cls.initialize()
+        return [
+            path(f"{name}/", HxEndpointView.as_view(hx_name=name), name=name)
+            for name in cls._registry
+        ]
 
     @classmethod
     def reset(cls):

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -94,6 +94,14 @@ class BaseHxRequest:
     #: :meth:`get_queryset` resolves the round-trip object through this model's
     #: default manager. Mirrors Django's ``SingleObjectMixin.model``.
     model = None
+    #: Optional Django view class to harvest page-view context from on the
+    #: router path (there is no page view in the request cycle there). When set,
+    #: the endpoint instantiates it, runs ``setup()``, and assigns it as the
+    #: context source -- reproducing the legacy implicit-context behavior with a
+    #: one-line declaration. Leave unset (the explicit, non-surprising default)
+    #: and a router handler simply gets no page-view context;
+    #: ``get_context_on_GET`` / ``get_context_on_POST`` / ``hx_object`` still work.
+    shares_context_from = None
     hx_object_name: str = "hx_object"
     GET_template: str | list = ""
     POST_template: str | list = ""
@@ -151,7 +159,7 @@ class BaseHxRequest:
             | self as hx_request
         """
         context = RequestContext(self.request)
-        if self.get_views_context and hasattr(self.view_response, "context_data"):
+        if self.view is not None and self.get_views_context and hasattr(self.view_response, "context_data"):
             context.update(self.view_response.context_data)
         if self.kwargs_as_context:
             context.update(kwargs)
@@ -182,7 +190,7 @@ class BaseHxRequest:
         if self.hx_object and self.hx_object.pk:
             with contextlib.suppress(ObjectDoesNotExist):
                 self.hx_object.refresh_from_db()
-        if self.refresh_views_context_on_POST:
+        if self.refresh_views_context_on_POST and self.view is not None:
             if hasattr(self.view, "object") and self.view.object:
                 self.view.object.refresh_from_db()
                 context["object"] = self.view.object
@@ -245,16 +253,19 @@ class BaseHxRequest:
         self._view_get_args = args
         self._view_get_kwargs = kwargs
         self.renderer = Renderer()
-        self.GET_template = self.GET_template or self.view.template_name
-        self.POST_template = self.POST_template or self.view.template_name
+        view_template = getattr(self.view, "template_name", None)
+        self.GET_template = self.GET_template or view_template
+        self.POST_template = self.POST_template or view_template
 
         if not hasattr(self, "hx_object"):
             self.hx_object = self.get_hx_object(request, **kwargs)
 
         # POST must snapshot the view context before post() mutates it; skip that
         # work when the POST renders nothing (refresh_page/redirect/return_empty).
+        # With no page view (router path) there is nothing to harvest.
         if (
-            self.get_views_context
+            self.view is not None
+            and self.get_views_context
             and self.is_post_request
             and not (self.refresh_page or self.redirect or self.return_empty)
         ):

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -159,7 +159,11 @@ class BaseHxRequest:
             | self as hx_request
         """
         context = RequestContext(self.request)
-        if self.view is not None and self.get_views_context and hasattr(self.view_response, "context_data"):
+        if (
+            getattr(self, "view", None) is not None
+            and self.get_views_context
+            and hasattr(self.view_response, "context_data")
+        ):
             context.update(self.view_response.context_data)
         if self.kwargs_as_context:
             context.update(kwargs)
@@ -190,7 +194,7 @@ class BaseHxRequest:
         if self.hx_object and self.hx_object.pk:
             with contextlib.suppress(ObjectDoesNotExist):
                 self.hx_object.refresh_from_db()
-        if self.refresh_views_context_on_POST and self.view is not None:
+        if self.refresh_views_context_on_POST and getattr(self, "view", None) is not None:
             if hasattr(self.view, "object") and self.view.object:
                 self.view.object.refresh_from_db()
                 context["object"] = self.view.object

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -182,15 +182,22 @@ def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
     # keeps working with no template edits.
     try:
         base = reverse(f"hx:{hx_request_name}")
+        on_router = True
     except NoReverseMatch:
         base = request.path
+        on_router = False
 
-    # The token is bound to the path it will actually be sent to (``base``) --
-    # the router endpoint URL when installed, else the current page path -- so a
-    # bind_to_path handler still verifies on the router (request.path there is the
-    # endpoint URL) while cross-path replay stays blocked. Handlers opt out with
-    # bind_to_path = False.
-    bind_path = base if _handler_binds_to_path(hx_request_name) else None
+    # Path-binding is a *legacy-dispatch* concept: query-param routing hides the
+    # handler behind the page URL, so the token is pinned to its render path to
+    # narrow cross-page replay. The router makes that redundant -- the handler has
+    # its own URL and the endpoint enforces name-binding -- so we do NOT path-bind
+    # on the router (binding to the single endpoint path would add nothing).
+    # Enforcement still honors a "path" claim if one is present (see
+    # bind_hx_token), so a legacy-minted bound token replayed at an endpoint is
+    # still rejected.
+    bind_path = None
+    if not on_router and _handler_binds_to_path(hx_request_name):
+        bind_path = request.path
     params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, bind_path=bind_path, **kwargs)
 
     return f"{base}?{urlencode(params, doseq=True)}"

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core import signing
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
+from django.urls import NoReverseMatch, reverse
 
 from hx_requests.constants import (
     HX_SIGNING_SALT,
@@ -176,12 +177,23 @@ def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
                 continue
             params[k] = v[0] if len(v) == 1 else v
 
-    # The token is bound to the path it is rendered on (so it only verifies when
-    # replayed back to this same path) unless the handler opts out.
-    bind_path = request.path if _handler_binds_to_path(hx_request_name) else None
+    # Prefer the router URL when it is installed; fall back to the current path
+    # (legacy page-view dispatch) so a project that has not wired the router
+    # keeps working with no template edits.
+    try:
+        base = reverse(f"hx:{hx_request_name}")
+    except NoReverseMatch:
+        base = request.path
+
+    # The token is bound to the path it will actually be sent to (``base``) --
+    # the router endpoint URL when installed, else the current page path -- so a
+    # bind_to_path handler still verifies on the router (request.path there is the
+    # endpoint URL) while cross-path replay stays blocked. Handlers opt out with
+    # bind_to_path = False.
+    bind_path = base if _handler_binds_to_path(hx_request_name) else None
     params[HX_TOKEN_PARAM] = sign_hx_payload(hx_request_name, obj, bind_path=bind_path, **kwargs)
 
-    return f"{request.path}?{urlencode(params, doseq=True)}"
+    return f"{base}?{urlencode(params, doseq=True)}"
 
 
 def _handler_binds_to_path(hx_request_name):

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -19,6 +19,90 @@ from hx_requests.utils import (
 logger = logging.getLogger(__name__)
 
 
+def bind_hx_token(request, expected_name=None):
+    """
+    Verify the signed ``hx`` token and rebuild ``request.GET`` so the rest of
+    the chain reads *trusted* framework data. Everything the framework controls
+    (name, object, kwargs) comes from the signed token; any client-supplied
+    framework params on the raw query string are dropped so they cannot shadow
+    or forge the verified values. Non-framework params (page filters, runtime
+    hx-vals) are left untouched.
+
+    When ``expected_name`` is given (the router path, where the name comes from
+    the URL), the token's ``name`` must equal it -- a token minted for one
+    handler cannot be replayed against another endpoint. Raises ``Http404`` on a
+    missing/tampered token, a name mismatch, or a path-binding mismatch.
+    """
+    if not request.GET.get(HX_TOKEN_PARAM):
+        logger.debug("hx_requests: denied (404) -- request carried no '%s' token.", HX_TOKEN_PARAM)
+        raise Http404("Missing required query param 'hx' for HTMX request.")
+    payload = get_hx_payload(request)
+    if payload is None:
+        logger.debug(
+            "hx_requests: denied (404) -- '%s' token was missing, tampered, or unsigned.",
+            HX_TOKEN_PARAM,
+        )
+        raise Http404("Invalid or tampered hx token.")
+    if expected_name is not None and payload["name"] != expected_name:
+        logger.debug(
+            "hx_requests: denied (404) -- token minted for '%s' replayed against '%s'.",
+            payload["name"],
+            expected_name,
+        )
+        raise Http404("hx token does not match this endpoint.")
+
+    # A path-bound token (bind_to_path handler) only verifies on the path it was
+    # minted for -- replaying it against another view's path is rejected. On the
+    # router this also holds: get_url binds the token to the endpoint URL it
+    # targets, so the check passes there and still blocks cross-path replay. The
+    # global HX_REQUESTS_BIND_TOKEN_TO_PATH switch disables the check so
+    # already-minted bound tokens stop 404ing the moment it is turned off.
+    bound_path = payload.get("path")
+    binding_enabled = getattr(settings, "HX_REQUESTS_BIND_TOKEN_TO_PATH", True)
+    if binding_enabled and bound_path is not None and bound_path != request.path:
+        logger.debug(
+            "hx_requests: denied (404) -- token bound to path '%s' replayed against '%s'.",
+            bound_path,
+            request.path,
+        )
+        raise Http404("hx token is bound to a different path.")
+
+    sanitized = request.GET.copy()
+    for key in list(sanitized.keys()):
+        if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+            del sanitized[key]
+    sanitized["hx_request_name"] = payload["name"]
+    if payload.get("object"):
+        sanitized["object"] = payload["object"]
+
+    request.GET = sanitized
+    # Verified, serialized kwargs from the token -- the only source of
+    # kwargs-as-context. Raw query params never feed this again.
+    request._hx_kwargs = payload.get("kwargs", {})
+    return request
+
+
+def merge_current_url(request):
+    """
+    Merge non-framework params from the ``HX-Current-URL`` header into
+    ``request.GET`` (the ``use_current_url`` behavior). Framework params
+    (name/object/kwargs/token) are never merged from the current URL: those are
+    trusted only via the signed token, not raw query input.
+    """
+    merged_get = request.GET.copy()
+    hx_current_url = request.headers.get("HX-Current-URL")
+    if hx_current_url:
+        parsed_url = urlparse(hx_current_url)
+        additional_params = parse_qs(parsed_url.query)
+        for key, values in additional_params.items():
+            if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+                continue
+            if key not in merged_get:
+                merged_get.setlist(key, values)
+    request.GET = merged_get
+    return request
+
+
 @method_decorator(ensure_csrf_cookie, name="dispatch")
 class HtmxViewMixin:
     """
@@ -76,47 +160,11 @@ class HtmxViewMixin:
         return hx_request_class()
 
     def _resolve_hx_token(self, request):
-        """
-        Verify the signed ``hx`` token and rebuild ``request.GET`` so the rest
-        of the chain reads *trusted* framework data. Everything the framework
-        controls (name, object, kwargs) comes from the signed token; any
-        client-supplied framework params on the raw query string are dropped so
-        they cannot shadow or forge the verified values. Non-framework params
-        (page filters, runtime hx-vals) are left untouched.
-        """
-        if not request.GET.get(HX_TOKEN_PARAM):
-            logger.debug("hx_requests: denied (404) -- request carried no '%s' token.", HX_TOKEN_PARAM)
-            raise Http404("Missing required query param 'hx' for HTMX request.")
-        payload = get_hx_payload(request)
-        if payload is None:
-            logger.debug(
-                "hx_requests: denied (404) -- '%s' token was missing, tampered, or unsigned.",
-                HX_TOKEN_PARAM,
-            )
-            raise Http404("Invalid or tampered hx token.")
-
-        # A path-bound token (bind_to_path handler) only verifies on the path it
-        # was minted for -- replaying it against another view's path is rejected.
-        # The global HX_REQUESTS_BIND_TOKEN_TO_PATH switch disables the check so
-        # already-minted bound tokens stop 404ing the moment it is turned off.
-        bound_path = payload.get("path")
-        binding_enabled = getattr(settings, "HX_REQUESTS_BIND_TOKEN_TO_PATH", True)
-        if binding_enabled and bound_path is not None and bound_path != request.path:
-            raise Http404("hx token is bound to a different path.")
-
-        sanitized = request.GET.copy()
-        for key in list(sanitized.keys()):
-            if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
-                del sanitized[key]
-        sanitized["hx_request_name"] = payload["name"]
-        if payload.get("object"):
-            sanitized["object"] = payload["object"]
-
-        request.GET = sanitized
-        # Verified, serialized kwargs from the token -- the only source of
-        # kwargs-as-context. Raw query params never feed this again.
-        request._hx_kwargs = payload.get("kwargs", {})
-        return request
+        # The trust boundary is shared with the router endpoint (see
+        # bind_hx_token): token validity + path binding (bind_to_path) apply on
+        # both paths. The legacy page-view path trusts the name inside the token,
+        # so no expected_name (router name binding) is enforced here.
+        return bind_hx_token(request)
 
     def get_hx_extra_kwargs(self, request):
         return deserialize_kwargs(**getattr(request, "_hx_kwargs", {}))
@@ -131,25 +179,4 @@ class HtmxViewMixin:
         return hx_request
 
     def _use_current_url(self, request):
-        # Start with the current GET params
-        merged_get = request.GET.copy()
-
-        # Check if HX-Current-URL is in the headers
-        hx_current_url = request.headers.get("HX-Current-URL")
-        if hx_current_url:
-            # Parse the URL and extract its query parameters
-            parsed_url = urlparse(hx_current_url)
-            additional_params = parse_qs(parsed_url.query)
-
-            # Add each HX param only if not already present. Framework params
-            # (name/object/kwargs/token) are never merged from the current URL:
-            # those are trusted only via the signed token, not raw query input.
-            for key, values in additional_params.items():
-                if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
-                    continue
-                if key not in merged_get:
-                    merged_get.setlist(key, values)
-
-        # Now override request.GET
-        request.GET = merged_get
-        return request
+        return merge_current_url(request)

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 from django.conf import settings
 from django.http import Http404
 from django.utils.decorators import method_decorator
+from django.views import View
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from hx_requests.constants import HX_TOKEN_PARAM, KWARG_PREFIX
@@ -180,3 +181,52 @@ class HtmxViewMixin:
 
     def _use_current_url(self, request):
         return merge_current_url(request)
+
+
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class HxEndpointView(View):
+    """
+    The router request cycle for one named ``HxRequest``.
+
+    Mounted at ``/hx/<name>/`` by :meth:`HxRequestRegistry.get_urls`. Because the
+    handler name comes from the URL path (not a client query param), a token
+    minted for one handler cannot be replayed against another endpoint -- the
+    endpoint asserts ``token.name == url.name`` (path binding). Per-handler
+    authorization is unchanged: it runs inside ``HxRequest.dispatch`` before
+    ``get`` / ``post``. Because this is a real Django ``View``, Django's own
+    ``login_required`` / ``LoginRequiredMixin`` compose natively on this path.
+    """
+
+    hx_name = None  # set per-path by as_view(hx_name=...)
+
+    def dispatch(self, request, *args, **kwargs):
+        hx_cls = HxRequestRegistry.get_hx_request(self.hx_name)
+        if hx_cls is None:
+            logger.debug(
+                "hx_requests: denied (404) -- no HxRequest registered under the name '%s'.",
+                self.hx_name,
+            )
+            raise Http404(f"No HxRequest found with the name '{self.hx_name}'.")
+
+        request = bind_hx_token(request, expected_name=self.hx_name)
+        kwargs.update(deserialize_kwargs(**getattr(request, "_hx_kwargs", {})))
+
+        hx_request = hx_cls()
+
+        # No page view in the router cycle. A handler opts back into page-view
+        # context with `shares_context_from = SomeView`; the endpoint stands that
+        # view up and assigns it as the context source (the same `view` seam the
+        # legacy path uses), so BaseHxRequest harvests it unchanged.
+        context_view_cls = getattr(hx_cls, "shares_context_from", None)
+        if context_view_cls is not None:
+            context_view = context_view_cls()
+            context_view.setup(request, *args, **kwargs)
+            hx_request.view = context_view
+        else:
+            hx_request.view = None
+
+        if getattr(hx_request, "use_current_url", False):
+            request = merge_current_url(request)
+
+        hx_request._setup_hx_request(request, *args, **kwargs)
+        return hx_request.dispatch(hx_request.request, *args, **kwargs)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,11 +8,14 @@ checks, form handling, trigger/header assembly, messages).
 
 from __future__ import annotations
 
+from urllib.parse import urlencode
+
 from django.contrib.auth.models import User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import RequestFactory
+from django.urls import reverse
 from django.views import View
 
 from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
@@ -63,6 +66,30 @@ def _create_test_request(
     request = set_request_attrs(request)
     add_middleware_to_request(request)
     return request
+
+
+def _router_query(hx_request, hx_kwargs=None, get_params=None):
+    hx_kwargs = dict(hx_kwargs or {})
+    get_params = dict(get_params or {})
+    hx_object = hx_kwargs.pop("object", None)
+    query = {HX_TOKEN_PARAM: sign_hx_payload(hx_request.name, hx_object, **hx_kwargs)}
+    query.update(get_params)
+    return query
+
+
+def hx_get_url(client, hx_request, hx_kwargs=None, get_params=None):
+    """Drive a GET through the router URL (reverse('hx:<name>'))."""
+    url = reverse(f"hx:{hx_request.name}")
+    return client.get(
+        url, data=_router_query(hx_request, hx_kwargs, get_params), HTTP_HX_REQUEST="true"
+    )
+
+
+def hx_post_url(client, hx_request, hx_kwargs=None, get_params=None, post_data=None):
+    """Drive a POST through the router URL (reverse('hx:<name>'))."""
+    url = reverse(f"hx:{hx_request.name}")
+    query = _router_query(hx_request, hx_kwargs, get_params)
+    return client.post(f"{url}?{urlencode(query)}", data=post_data or {}, HTTP_HX_REQUEST="true")
 
 
 def hx_get(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -80,9 +80,7 @@ def _router_query(hx_request, hx_kwargs=None, get_params=None):
 def hx_get_url(client, hx_request, hx_kwargs=None, get_params=None):
     """Drive a GET through the router URL (reverse('hx:<name>'))."""
     url = reverse(f"hx:{hx_request.name}")
-    return client.get(
-        url, data=_router_query(hx_request, hx_kwargs, get_params), HTTP_HX_REQUEST="true"
-    )
+    return client.get(url, data=_router_query(hx_request, hx_kwargs, get_params), HTTP_HX_REQUEST="true")
 
 
 def hx_post_url(client, hx_request, hx_kwargs=None, get_params=None, post_data=None):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(BASE_DIR))
 SECRET_KEY = "test-secret-key-not-for-production"
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
-ROOT_URLCONF = None
+ROOT_URLCONF = "urls"
 USE_TZ = True
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 

--- a/tests/templates/view_flavor.html
+++ b/tests/templates/view_flavor.html
@@ -1,0 +1,1 @@
+<div>{{ view_flavor|default:"no-view-context" }}</div>

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.http import HttpResponse
 from test_app.forms import WidgetForm
 from test_app.models import Gadget, Widget
+from test_app.views import RouterContextView
 
 from hx_requests.hx_requests import (
     BaseHxRequest,
@@ -384,3 +385,16 @@ class OwnerOnlyHx(BaseHxRequest):
 
     def has_permission(self, request):
         return getattr(request.user, "username", None) == "owner"
+
+
+# --------------------------------------------------------------------------
+# Router: context sharing (#10)
+# --------------------------------------------------------------------------
+
+
+class SharesContextHx(BaseHxRequest):
+    """Reproduces page-view context on the router path via shares_context_from."""
+
+    name = "shares_context"
+    GET_template = "view_flavor.html"
+    shares_context_from = RouterContextView

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -14,6 +14,18 @@ class BaseView(HtmxViewMixin, TemplateView):
         return context
 
 
+class RouterContextView(TemplateView):
+    """A plain view (no HtmxViewMixin) used only as a ``shares_context_from``
+    context source on the router path."""
+
+    template_name = "base_view.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["view_flavor"] = "from-the-view"
+        return context
+
+
 class WidgetListView(HtmxViewMixin, ListView):
     model = Widget
     template_name = "widget_list.html"

--- a/tests/test_hx_tags.py
+++ b/tests/test_hx_tags.py
@@ -32,8 +32,10 @@ def payload_from_attr(attr, name="hx-get"):
 
 
 def test_hx_get_renders_quoted_attribute():
+    # simple_get is a registered handler, so the router is reverse()d
+    # (tests/urls.py mounts it) in preference to the current path.
     out = hx_get(make_context(), "simple_get")
-    assert out.startswith('hx-get="/page/?')
+    assert out.startswith('hx-get="/hx/simple_get/?')
     assert out.endswith('"')
     assert payload_from_attr(out)["name"] == "simple_get"
 
@@ -49,7 +51,7 @@ def test_hx_get_includes_object_and_kwargs(widget):
 
 def test_hx_post_renders_quoted_attribute_and_csrf_headers():
     out = hx_post(make_context(), "simple_get")
-    assert out.startswith('hx-post="/page/?')
+    assert out.startswith('hx-post="/hx/simple_get/?')
     assert payload_from_attr(out, "hx-post")["name"] == "simple_get"
 
     # hx-headers is emitted as a quoted attribute carrying JSON; the JSON's
@@ -71,7 +73,7 @@ def test_hx_post_always_includes_csrf_headers():
 
 def test_hx_url_returns_bare_url():
     out = hx_url(make_context(), "simple_get")
-    assert out.startswith("/page/?")
+    assert out.startswith("/hx/simple_get/?")
     query = parse_qs(urlparse(out).query)
     assert unsign_hx_payload(query[HX_TOKEN_PARAM][0])["name"] == "simple_get"
 
@@ -79,6 +81,6 @@ def test_hx_url_returns_bare_url():
 def test_tags_render_through_the_template_engine():
     template = Template("{% load hx_tags %}{% hx_url 'simple_get' %}")
     rendered = template.render(Context(make_context()))
-    assert rendered.startswith("/page/?")
+    assert rendered.startswith("/hx/simple_get/?")
     query = parse_qs(urlparse(rendered).query)
     assert unsign_hx_payload(query[HX_TOKEN_PARAM][0])["name"] == "simple_get"

--- a/tests/test_path_binding.py
+++ b/tests/test_path_binding.py
@@ -41,9 +41,11 @@ def _bound_request(path, bound_to):
 
 
 def test_tokens_are_path_bound_by_default():
-    # Path-binding is on by default: an ordinary handler binds its render path.
+    # Path-binding is on by default: an ordinary handler binds the URL its token
+    # will be sent to. With the router installed (tests/urls.py), get_url targets
+    # -- and so binds to -- the router endpoint URL rather than the render path.
     out = hx_url({"request": RequestFactory().get("/page/")}, "simple_get")
-    assert _payload_from_url(out).get("path") == "/page/"
+    assert _payload_from_url(out).get("path") == "/hx/simple_get/"
 
 
 def test_opted_out_handler_has_no_path():

--- a/tests/test_path_binding.py
+++ b/tests/test_path_binding.py
@@ -40,14 +40,20 @@ def _bound_request(path, bound_to):
     return request
 
 
+# Path-binding at mint is a *legacy-dispatch* behavior: it only applies when the
+# /hx/<name>/ router is not installed (the router makes it redundant -- see
+# test_url_router.test_router_minted_token_is_not_path_bound). These mint tests
+# therefore run against a router-less URLconf so they exercise the legacy path.
+
+
+@override_settings(ROOT_URLCONF="urls_no_router")
 def test_tokens_are_path_bound_by_default():
-    # Path-binding is on by default: an ordinary handler binds the URL its token
-    # will be sent to. With the router installed (tests/urls.py), get_url targets
-    # -- and so binds to -- the router endpoint URL rather than the render path.
+    # Path-binding is on by default: an ordinary handler binds its render path.
     out = hx_url({"request": RequestFactory().get("/page/")}, "simple_get")
-    assert _payload_from_url(out).get("path") == "/hx/simple_get/"
+    assert _payload_from_url(out).get("path") == "/page/"
 
 
+@override_settings(ROOT_URLCONF="urls_no_router")
 def test_opted_out_handler_has_no_path():
     # A handler with bind_to_path = False mints an unbound token.
     out = hx_url({"request": RequestFactory().get("/page/")}, "unbound")
@@ -69,7 +75,7 @@ def test_bound_token_on_its_own_path_is_accepted():
     assert request.GET["hx_request_name"] == "simple_get"
 
 
-@override_settings(HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
+@override_settings(ROOT_URLCONF="urls_no_router", HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
 def test_global_setting_disables_binding_at_mint():
     # The global kill switch stops new tokens from being path-bound at all.
     out = hx_url({"request": RequestFactory().get("/page/")}, "simple_get")

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -157,3 +157,49 @@ def test_get_url_falls_back_to_request_path_for_unknown_name(rf, clean_registry)
     request = rf.get("/some/page/")
     url = get_url({"request": request}, "not_a_registered_router_name", None)
     assert url.startswith("/some/page/?")
+
+
+# --------------------------------------------------------------------------
+# Context sharing, plain-htmx fall-through, startup ordering
+# --------------------------------------------------------------------------
+
+
+def test_shares_context_from_reproduces_view_context(hx_client, clean_registry):
+    from test_app.hx_requests import SharesContextHx
+
+    from tests.helpers import hx_get_url
+
+    response = hx_get_url(hx_client, SharesContextHx)
+    assert response.status_code == 200
+    assert b"from-the-view" in response.content
+
+
+def test_no_shares_context_gets_no_view_context(hx_client, clean_registry):
+    from django.urls import reverse
+
+    # simple_get has no shares_context_from; view context is simply absent.
+    # (It renders fine because it declares its own GET_template.)
+    response = hx_client.get(
+        reverse("hx:simple_get"),
+        data={HX_TOKEN_PARAM: sign_hx_payload("simple_get")},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 200
+
+
+def test_plain_htmx_without_token_is_not_a_router_request():
+    # A token-less HTMX request carries no signed payload, so it is not an
+    # hx-requests request -- the page view (legacy path) handles it. The router
+    # only mounts named handlers; it never intercepts token-less htmx.
+    from hx_requests.utils import is_hx_request
+
+    request = RequestFactory().get("/", HTTP_HX_REQUEST="true")
+    assert is_hx_request(request) is False
+
+
+def test_urlconf_builds_without_touching_the_registry(clean_registry):
+    # Importing the URLconf must build patterns without error even if the
+    # registry was reset (initialize() runs inside get_urls()).
+    HxRequestRegistry.reset()
+    urls = HxRequestRegistry.get_urls()
+    assert any(p.name == "simple_get" for p in urls)

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from django.test import RequestFactory
 
 from hx_requests.hx_registry import HxRequestRegistry
+from hx_requests.hx_requests import BaseHxRequest
 from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
 from hx_requests.views import bind_hx_token
 
@@ -28,3 +29,28 @@ def test_bind_hx_token_accepts_matching_name():
     request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
     bound = bind_hx_token(request, expected_name="simple_get")
     assert bound.GET["hx_request_name"] == "simple_get"
+
+
+# --------------------------------------------------------------------------
+# BaseHxRequest without a page view (router path)
+# --------------------------------------------------------------------------
+
+
+def test_base_hx_request_sets_up_with_no_view():
+    class NoViewHx(BaseHxRequest):
+        name = "no_view_hx_unit"
+        GET_template = "simple.html"
+
+    hx = NoViewHx()
+    hx.view = None
+    request = RequestFactory().get("/")
+    request.user = None
+    # Must not raise despite there being no page view to harvest context from.
+    hx._setup_hx_request(request)
+    assert hx.GET_template == "simple.html"
+    context = hx.get_context_data()
+    assert context["hx_request"] is hx
+
+
+def test_shares_context_from_defaults_to_none():
+    assert BaseHxRequest.shares_context_from is None

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -136,6 +136,38 @@ def test_router_enforces_per_handler_auth(db, clean_registry):
     assert response.status_code == 404
 
 
+def test_router_composes_with_bind_to_path(hx_client, clean_registry):
+    from urllib.parse import urlparse
+
+    from hx_requests.utils import get_url
+
+    # A bind_to_path handler (the default): get_url binds the token to the router
+    # endpoint URL it targets, so dispatching that exact URL through the endpoint
+    # verifies (request.path there == the bound path).
+    url = get_url({"request": RequestFactory().get("/page/")}, "simple_get", None)
+    assert urlparse(url).path == "/hx/simple_get/"
+    response = hx_client.get(url, HTTP_HX_REQUEST="true")
+    assert response.status_code == 200
+
+
+def test_router_rejects_token_bound_to_a_different_path(hx_client, clean_registry):
+    from django.core import signing
+    from django.urls import reverse
+
+    from hx_requests.utils import HX_SIGNING_SALT
+
+    # A token bound to the legacy page path, replayed against the router
+    # endpoint, is rejected by the path-binding check.
+    token = signing.dumps(
+        {"name": "simple_get", "object": None, "kwargs": {}, "path": "/page/"},
+        salt=HX_SIGNING_SALT,
+    )
+    response = hx_client.get(
+        reverse("hx:simple_get"), data={HX_TOKEN_PARAM: token}, HTTP_HX_REQUEST="true"
+    )
+    assert response.status_code == 404
+
+
 # --------------------------------------------------------------------------
 # Template tag get_url(): reverse() with a legacy fallback
 # --------------------------------------------------------------------------

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -1,0 +1,30 @@
+"""Tests for the additive /hx/<name>/ URL router (#10)."""
+
+from __future__ import annotations
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+
+from hx_requests.hx_registry import HxRequestRegistry
+from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
+from hx_requests.views import bind_hx_token
+
+# --------------------------------------------------------------------------
+# Shared token trust boundary (bind_hx_token)
+# --------------------------------------------------------------------------
+
+
+def test_bind_hx_token_rejects_name_mismatch():
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
+    # A token minted for simple_get replayed against another endpoint 404s.
+    with pytest.raises(Http404):
+        bind_hx_token(request, expected_name="post_template")
+
+
+def test_bind_hx_token_accepts_matching_name():
+    token = sign_hx_payload("simple_get")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token})
+    bound = bind_hx_token(request, expected_name="simple_get")
+    assert bound.GET["hx_request_name"] == "simple_get"

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -136,16 +136,19 @@ def test_router_enforces_per_handler_auth(db, clean_registry):
     assert response.status_code == 404
 
 
-def test_router_composes_with_bind_to_path(hx_client, clean_registry):
-    from urllib.parse import urlparse
+def test_router_minted_token_is_not_path_bound(hx_client, clean_registry):
+    from urllib.parse import parse_qs, urlparse
 
-    from hx_requests.utils import get_url
+    from hx_requests.utils import get_url, unsign_hx_payload
 
-    # A bind_to_path handler (the default): get_url binds the token to the router
-    # endpoint URL it targets, so dispatching that exact URL through the endpoint
-    # verifies (request.path there == the bound path).
+    # On the router, path-binding is redundant: the handler has its own URL and
+    # the endpoint enforces name-binding, so get_url does NOT path-bind (even for
+    # a bind_to_path=True handler). The token carries no "path" claim, and it
+    # still dispatches through the endpoint.
     url = get_url({"request": RequestFactory().get("/page/")}, "simple_get", None)
     assert urlparse(url).path == "/hx/simple_get/"
+    payload = unsign_hx_payload(parse_qs(urlparse(url).query)[HX_TOKEN_PARAM][0])
+    assert "path" not in payload
     response = hx_client.get(url, HTTP_HX_REQUEST="true")
     assert response.status_code == 200
 

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -54,3 +54,83 @@ def test_base_hx_request_sets_up_with_no_view():
 
 def test_shares_context_from_defaults_to_none():
     assert BaseHxRequest.shares_context_from is None
+
+
+# --------------------------------------------------------------------------
+# Registry -> urlpatterns
+# --------------------------------------------------------------------------
+
+
+def test_get_urls_returns_one_pattern_per_registered_name(clean_registry):
+    HxRequestRegistry.reset()
+    HxRequestRegistry.initialize()
+    urls = HxRequestRegistry.get_urls()
+
+    names = {pattern.name for pattern in urls}
+    assert "simple_get" in names
+    assert "other_app_hx" in names
+    assert "deep_hx" in names
+    assert len(urls) == len(HxRequestRegistry._registry)
+
+
+def test_get_urls_does_not_import_handler_classes(clean_registry):
+    HxRequestRegistry.reset()
+    HxRequestRegistry.get_urls()
+    # Building URLs must stay lazy: entries remain (module, class) tuples.
+    assert isinstance(HxRequestRegistry._registry["simple_get"], tuple)
+
+
+# --------------------------------------------------------------------------
+# Router endpoint (HxEndpointView) via real resolved URLs
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def hx_client(db, django_user_model):
+    """A logged-in test client (handlers default to login_required=True)."""
+    from django.test import Client
+
+    user = django_user_model.objects.create_user(username="router", password="pw")
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+def test_router_dispatches_get_to_handler(hx_client, clean_registry):
+    from test_app.hx_requests import SimpleGetHx
+
+    from tests.helpers import hx_get_url
+
+    response = hx_get_url(hx_client, SimpleGetHx)
+    assert response.status_code == 200
+    assert b"simple" in response.content.lower()
+
+
+def test_router_path_binding_rejects_replayed_token(hx_client, clean_registry):
+    from django.urls import reverse
+    from test_app.hx_requests import SimpleGetHx
+
+    # Token minted for simple_get, sent to post_template's URL -> 404.
+    url = reverse("hx:post_template")
+    token = sign_hx_payload(SimpleGetHx.name)
+    response = hx_client.get(url, data={HX_TOKEN_PARAM: token}, HTTP_HX_REQUEST="true")
+    assert response.status_code == 404
+
+
+def test_router_missing_token_404s(hx_client, clean_registry):
+    from django.urls import reverse
+
+    response = hx_client.get(reverse("hx:simple_get"), HTTP_HX_REQUEST="true")
+    assert response.status_code == 404
+
+
+def test_router_enforces_per_handler_auth(db, clean_registry):
+    from django.test import Client
+    from test_app.hx_requests import SimpleGetHx
+
+    from tests.helpers import hx_get_url
+
+    # Anonymous client + login_required default -> 404 (bodiless).
+    anon = Client()
+    response = hx_get_url(anon, SimpleGetHx)
+    assert response.status_code == 404

--- a/tests/test_url_router.py
+++ b/tests/test_url_router.py
@@ -134,3 +134,26 @@ def test_router_enforces_per_handler_auth(db, clean_registry):
     anon = Client()
     response = hx_get_url(anon, SimpleGetHx)
     assert response.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Template tag get_url(): reverse() with a legacy fallback
+# --------------------------------------------------------------------------
+
+
+def test_get_url_uses_reverse_when_router_installed(rf, clean_registry):
+    from hx_requests.utils import get_url
+
+    request = rf.get("/some/page/")
+    url = get_url({"request": request}, "simple_get", None)
+    # Router installed (tests/urls.py) -> reversed router URL, not request.path.
+    assert url.startswith("/hx/simple_get/?")
+    assert "hx=" in url
+
+
+def test_get_url_falls_back_to_request_path_for_unknown_name(rf, clean_registry):
+    from hx_requests.utils import get_url
+
+    request = rf.get("/some/page/")
+    url = get_url({"request": request}, "not_a_registered_router_name", None)
+    assert url.startswith("/some/page/?")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,7 +246,9 @@ def token_from_url(url):
 
 def test_get_url_basic():
     url = get_url(make_context(), "simple_get", None)
-    assert url.startswith("/page/?")
+    # simple_get is a registered handler, so get_url reverse()s the router URL
+    # (tests/urls.py mounts it) in preference to the request path.
+    assert url.startswith("/hx/simple_get/?")
     payload = token_from_url(url)
     assert payload["name"] == "simple_get"
     assert payload["object"] is None

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,9 @@
+"""Root URLconf for the test suite: mounts the additive HxRequest router."""
+
+from django.urls import include, path
+
+from hx_requests.hx_registry import HxRequestRegistry
+
+urlpatterns = [
+    path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx")),
+]

--- a/tests/urls_no_router.py
+++ b/tests/urls_no_router.py
@@ -1,0 +1,7 @@
+"""A router-less root URLconf.
+
+Used by tests that exercise *legacy* dispatch behavior (e.g. path-binding at
+mint), which only applies when the ``/hx/<name>/`` router is not installed.
+"""
+
+urlpatterns = []


### PR DESCRIPTION
Implements #10 — the **additive `/hx/<name>/` URL router** — on top of the design spec (which remains in this branch under `docs/superpowers/specs/`). Built test-first; full suite green (231 passed), ruff clean.

## What ships

- **Registry → urlpatterns.** `HxRequestRegistry.get_urls()` builds one `path()` per registered *name* (names only — lazy import preserved), routed through `HxEndpointView`. Wire once: `path("hx/", include((HxRequestRegistry.get_urls(), "hx_requests"), namespace="hx"))`.
- **`HxEndpointView`** — a real Django `View` that verifies the signed token, enforces **path binding** (token name must equal the URL name → closes the "token replayable across handlers" gap with an `Http404`), and runs the existing `HxRequest.dispatch` (per-handler auth + get/post unchanged). Django's own `login_required` / `LoginRequiredMixin` compose natively here.
- **One trust boundary.** Token verify/sanitize and current-URL merge are factored into `bind_hx_token` / `merge_current_url`, shared by both `HtmxViewMixin` (legacy) and `HxEndpointView` (router).
- **Template tags** (`hx_get`/`hx_post`/`hx_url`) prefer `reverse("hx:<name>")`, falling back to `request.path` on `NoReverseMatch` — zero-config and additive; templates need no edits.
- **Context sharing.** With no page view in the router cycle, a handler opts back in with `shares_context_from = SomeView`; the endpoint stands that view up and reuses the existing `view` harvest seam. Absent it, the handler gets no page-view context (explicit; `hx_object` / `get_context_on_*` still work).

**Preserved:** many-handlers-one-registration, the form/modal round-trip, composable mixins, and plain-htmx fall-through. Legacy query-param dispatch is untouched; removing it is a separate later `feat!:`.

## Open questions (resolved to the spec's recommended defaults)

1. Legacy dispatch → additive now, clean-break later. 2. Namespace → fixed `hx:`. 3. `get_urls()` timing → `initialize()` at URLconf-build time (patterns are a snapshot; adding a handler needs a restart). 4. `shares_context_from` preamble → reuse the `view` seam rather than resurrecting `django_views.py` (YAGNI; `TemplateView`/`ListView` supported, pk-bound `DetailView`/`UpdateView` out of scope — use `hx_object`).

## Notes / to confirm

- The user was AFK when I picked this up; I proceeded on the green-light ("work on pr for #10, here is the spec") using the spec's documented defaults for every open question. Happy to revisit any of them.
- This branch is based on `feat/per-handler-auth` and does **not** carry #202's GET-write guard (sibling branch). The guard composes automatically on the router path once #202 is in the base (it lives in `HxRequest.dispatch`).
- Plan: `docs/superpowers/plans/2026-07-08-url-router.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
