### PR TITLE
fix(#4)!: serialization round-trip correctness

### DIFF
--- a/hx_requests/constants.py
+++ b/hx_requests/constants.py
@@ -1,5 +1,4 @@
 MODEL_INSTANCE_PREFIX = "model_instance__"
-KWARG_PREFIX = "___"
 
 # Query param that carries the signed round-trip token, and the signing salt.
 # The salt only namespaces the signature; secrecy comes from SECRET_KEY. A

--- a/hx_requests/utils.py
+++ b/hx_requests/utils.py
@@ -10,7 +10,6 @@ from django.db import models
 from hx_requests.constants import (
     HX_SIGNING_SALT,
     HX_TOKEN_PARAM,
-    KWARG_PREFIX,
     MODEL_INSTANCE_PREFIX,
 )
 
@@ -19,6 +18,11 @@ __ = "__"
 
 def serialize(value):
     if isinstance(value, models.Model):
+        if value.pk is None:
+            raise ValueError(
+                f"Cannot serialize an unsaved {value._meta.label} instance (pk is None). "
+                "Save the object before passing it to an hx tag."
+            )
         return (
             f"{MODEL_INSTANCE_PREFIX}{value._meta.app_label}{__}{value._meta.model_name}{__}{value.pk}"
         )
@@ -34,7 +38,9 @@ def parse_model_ref(value):
     can't be mangled.
     """
     if isinstance(value, str) and value.startswith(MODEL_INSTANCE_PREFIX):
-        app_label, model_name, pk = value[len(MODEL_INSTANCE_PREFIX) :].split(__)
+        # maxsplit=2: app label and model name never contain '__', so the
+        # remaining tail is kept intact as the pk (which legitimately may).
+        app_label, model_name, pk = value[len(MODEL_INSTANCE_PREFIX) :].split(__, 2)
         return app_label, model_name, pk
     return None
 
@@ -69,21 +75,16 @@ def is_htmx_request(request):
 
 
 def serialize_kwargs(**kwargs):
-    serialized_kwargs = {}
-    for k, v in kwargs.items():
-        prefixed_k = KWARG_PREFIX + k
-        serialized_kwargs[prefixed_k] = serialize(v)
-    return serialized_kwargs
+    # Kwargs live inside the signed token's ``kwargs`` sub-dict, keyed by their
+    # real names -- a dedicated dict, not loose query params.
+    return {k: serialize(v) for k, v in kwargs.items()}
 
 
 def deserialize_kwargs(**kwargs):
-    deserialized_kwargs = {}
-    for k, v in kwargs.items():
-        if not k.startswith(KWARG_PREFIX):
-            continue
-        prefixed_k = k.replace(KWARG_PREFIX, "")
-        deserialized_kwargs[prefixed_k] = deserialize(v)
-    return deserialized_kwargs
+    # The inverse of :func:`serialize_kwargs`. Every entry is a real kwarg
+    # (this is only ever fed the token's verified ``kwargs`` dict), so each is
+    # deserialized as-is with no prefix handling.
+    return {k: deserialize(v) for k, v in kwargs.items()}
 
 
 def sign_hx_payload(hx_request_name, obj=None, bind_path=None, **kwargs):
@@ -172,7 +173,7 @@ def get_url(context, hx_request_name, obj, use_full_path=False, **kwargs):
     params = {}
     if use_full_path:
         for k, v in request.GET.lists():
-            if k in (HX_TOKEN_PARAM, "hx_request_name", "object") or k.startswith(KWARG_PREFIX):
+            if k in (HX_TOKEN_PARAM, "hx_request_name", "object"):
                 continue
             params[k] = v[0] if len(v) == 1 else v
 

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -8,7 +8,7 @@ from django.http import Http404, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from hx_requests.constants import HX_TOKEN_PARAM, KWARG_PREFIX
+from hx_requests.constants import HX_TOKEN_PARAM
 from hx_requests.hx_registry import HxRequestRegistry
 from hx_requests.security_utils import (
     app_label_for_object,
@@ -117,7 +117,7 @@ class HtmxViewMixin:
 
         sanitized = request.GET.copy()
         for key in list(sanitized.keys()):
-            if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+            if key in (HX_TOKEN_PARAM, "hx_request_name", "object"):
                 del sanitized[key]
         sanitized["hx_request_name"] = payload["name"]
         if payload.get("object"):
@@ -206,7 +206,7 @@ class HtmxViewMixin:
             # (name/object/kwargs/token) are never merged from the current URL:
             # those are trusted only via the signed token, not raw query input.
             for key, values in additional_params.items():
-                if key in (HX_TOKEN_PARAM, "hx_request_name", "object") or key.startswith(KWARG_PREFIX):
+                if key in (HX_TOKEN_PARAM, "hx_request_name", "object"):
                     continue
                 if key not in merged_get:
                     merged_get.setlist(key, values)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -62,7 +62,6 @@ def test_resolve_strips_client_supplied_framework_params():
         data={
             HX_TOKEN_PARAM: token,
             "object": "model_instance__test_app__widget__999",
-            "___evil": '"x"',
             "hx_request_name": "other",
             "page": "2",
         },
@@ -72,7 +71,8 @@ def test_resolve_strips_client_supplied_framework_params():
     BaseView()._resolve_hx_token(request)
 
     assert request.GET.get("object") is None  # loose object dropped, token had none
-    assert "___evil" not in request.GET  # loose kwarg dropped
     assert request.GET["hx_request_name"] == "simple_get"  # from token, not "other"
     assert request.GET["page"] == "2"  # legit loose param preserved
+    # A loose param a client invents (whatever its name) is harmless: kwargs are
+    # sourced only from the signed token, never from raw query input.
     assert request._hx_kwargs == {}  # kwargs sourced only from the token

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,16 @@ def test_dates_serialize_via_django_json_encoder():
     assert serialize(datetime.date(2020, 1, 2)) == '"2020-01-02"'
 
 
+def test_serialize_unsaved_instance_fails_loudly():
+    # An unsaved instance has pk=None; serializing it produced '...__None',
+    # which later blew up in queryset.get(pk="None"). Fail at serialize time
+    # with a clear error instead.
+    widget = Widget(name="unsaved")
+    assert widget.pk is None
+    with pytest.raises(ValueError, match="unsaved"):
+        serialize(widget)
+
+
 @pytest.mark.django_db()
 def test_deserialize_uses_default_manager():
     # Resolution goes through the *default* manager, so anything the default
@@ -84,6 +94,18 @@ def test_parse_model_ref_returns_none_for_non_model_values(value):
     assert parse_model_ref(value) is None
 
 
+def test_parse_model_ref_pk_may_contain_double_underscore():
+    # A string PK containing '__' is legitimate (server-minted). Splitting
+    # without a maxsplit produced too many segments -> ValueError -> 500.
+    # App label and model name never contain '__', so a left split with
+    # maxsplit 2 keeps the whole tail as the pk.
+    assert parse_model_ref("model_instance__test_app__widget__a__b") == (
+        "test_app",
+        "widget",
+        "a__b",
+    )
+
+
 @pytest.mark.django_db()
 def test_resolve_model_ref_uses_default_manager_by_default():
     gadget = Gadget.objects.create(name="visible")
@@ -107,13 +129,13 @@ def test_resolve_model_ref_honors_a_scoped_queryset(widget):
 # --------------------------------------------------------------------------
 
 
-def test_serialize_kwargs_prefixes_keys():
-    assert serialize_kwargs(flavor="spicy") == {"___flavor": '"spicy"'}
+def test_serialize_kwargs_keys_are_unprefixed():
+    assert serialize_kwargs(flavor="spicy") == {"flavor": '"spicy"'}
 
 
-def test_deserialize_kwargs_strips_prefix_and_ignores_other_keys():
-    result = deserialize_kwargs(___flavor='"spicy"', plain="ignored", hx_request_name="x")
-    assert result == {"flavor": "spicy"}
+def test_deserialize_kwargs_deserializes_every_entry():
+    result = deserialize_kwargs(flavor='"spicy"', count="3")
+    assert result == {"flavor": "spicy", "count": 3}
 
 
 @pytest.mark.django_db()
@@ -125,6 +147,15 @@ def test_kwargs_round_trip_with_model_instance(widget):
 
 def test_none_kwarg_round_trip():
     assert deserialize_kwargs(**serialize_kwargs(maybe=None)) == {"maybe": None}
+
+
+def test_kwarg_name_containing_prefix_sequence_round_trips():
+    # A kwarg whose name contains the '___' sequence must survive the
+    # serialize -> deserialize round trip unchanged. The old prefix-strip
+    # (str.replace) removed *every* occurrence, silently renaming
+    # 'foo___bar' -> 'foobar'.
+    serialized = serialize_kwargs(**{"foo___bar": "x"})
+    assert deserialize_kwargs(**serialized) == {"foo___bar": "x"}
 
 
 # --------------------------------------------------------------------------
@@ -273,12 +304,16 @@ def test_get_url_use_full_path_carries_existing_params():
 
 
 def test_get_url_use_full_path_filters_internal_params():
-    context = make_context("/page/?q=search&hx_request_name=old&object=x&___junk=%22y%22")
+    context = make_context("/page/?q=search&hx_request_name=old&object=x&extra=keep")
     url = get_url(context, "new_name", None, use_full_path=True)
     query = parse_qs(urlparse(url).query)
     assert query["q"] == ["search"]
     # Stale framework params from the current URL are not re-emitted loose.
     assert "hx_request_name" not in query
     assert "object" not in query
-    assert "___junk" not in query
+    # Ordinary loose params (page filters etc.) are carried forward untouched.
+    # There is no longer any '___'-prefixed "framework kwarg" notion: kwargs
+    # travel only inside the signed token, so nothing on the query string is
+    # treated as special beyond the token param and the two legacy names above.
+    assert query["extra"] == ["keep"]
     assert token_from_url(url)["name"] == "new_name"


### PR DESCRIPTION
Audit round 2, item **#4** — serialization / round-trip bugs (all reproduced). Stacked PR **1 of 6**, base `master`. TDD'd; suite green.

- `parse_model_ref` splits with `maxsplit=2`, so string PKs containing `__` no longer 500.
- Serializing an unsaved instance (`pk is None`) fails loudly with a clear `ValueError` instead of minting a `...__None` reference that blew up later in `queryset.get(pk="None")`.
- Kwargs round-trip under their real names inside the signed token's `kwargs` sub-dict. The old `KWARG_PREFIX` (`___`) strip used `str.replace`, silently renaming e.g. `foo___bar` → `foobar`. That prefix is removed entirely, along with the now-dead `startswith(KWARG_PREFIX)` guards in `get_url`, the dispatch sanitize loop, and the HX-Current-URL merge.

BREAKING CHANGE: the `hx_requests.constants.KWARG_PREFIX` constant is removed, and `___`-prefixed loose query params are no longer treated specially by the framework.

Migration — kwargs are now addressed by their real (unprefixed) names everywhere. Handler and template code is unaffected: kwargs already arrive under their real names, merged into the context (or under `hx_kwargs` when `kwargs_as_context = False`). Only code that reached for the prefix itself needs to change — replace any `request.GET["___foo"]` lookup or `KWARG_PREFIX` import with the verified token kwargs, e.g. `deserialize_kwargs(**get_hx_payload(request)["kwargs"])["foo"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
