### PR TITLE
fix(#5): let hx-boost and plain htmx fall through the mixin

### DIFF
--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -45,7 +45,11 @@ class HtmxViewMixin:
         # handoff runs first and skips them. `check_auth_mixin_ordering`
         # (checks.py) warns at startup when an auth mixin is ordered after this
         # mixin; enforce per-handler authorization on the HxRequest itself.
-        if is_htmx_request(request) and request.method.lower() in self.http_method_names:
+        if (
+            is_htmx_request(request)
+            and request.GET.get(HX_TOKEN_PARAM)
+            and request.method.lower() in self.http_method_names
+        ):
             request = self._resolve_hx_token(request)
             kwargs.update(self.get_hx_extra_kwargs(request))
             hx_request = self._setup_hx_request(request, *args, **kwargs)
@@ -53,9 +57,9 @@ class HtmxViewMixin:
             # Use request from hx_request, in case use_current_url is set to True
             return hx_request.dispatch(hx_request.request, *args, **kwargs)
 
-        # Non-HTMX requests (full page loads, plain-htmx the view handles
-        # itself) chain through super().dispatch() so the page view's own
-        # mixins run normally instead of being short-circuited.
+        # No hx token: fall through to the page view's normal dispatch (full
+        # page loads, hx-boost, and plain htmx all land here). A present-but-
+        # invalid token never reaches this line -- it is rejected above.
         return super().dispatch(request, *args, **kwargs)
 
     def get_hx_request(self, request):

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -374,12 +374,30 @@ def test_non_htmx_request_falls_through_to_the_view():
     assert "view_flavor:from-the-view" in content_of(response)
 
 
-def test_missing_hx_token_raises_404():
+def test_htmx_request_without_token_falls_through_to_the_view():
+    # An htmx request that carries no hx token is plain htmx (a hand-written
+    # hx-get widget, sort/filter/paginate) -- it must reach the page view, not
+    # 404. Only a present-but-invalid token is a hard error.
     request = RequestFactory().get("/")
     request.META["HTTP_HX_REQUEST"] = True
     add_middleware_to_request(request)
-    with pytest.raises(Http404, match="Missing required query param"):
-        BaseView.as_view()(request)
+    response = BaseView.as_view()(request)
+    response.render()
+    assert response.status_code == 200
+    assert "base-view-template" in content_of(response)
+
+
+def test_boosted_request_falls_through_to_the_view():
+    # hx-boost navigation sends the HX-Request (+ HX-Boosted) header but no hx
+    # token; boosting to a mixin view must render the page, not 404.
+    request = RequestFactory().get("/")
+    request.META["HTTP_HX_REQUEST"] = True
+    request.META["HTTP_HX_BOOSTED"] = True
+    add_middleware_to_request(request)
+    response = BaseView.as_view()(request)
+    response.render()
+    assert response.status_code == 200
+    assert "base-view-template" in content_of(response)
 
 
 def test_tampered_hx_token_raises_404():


### PR DESCRIPTION
Audit round 2, item **#5**. Stacked PR **2 of 6**, base `audit2/serialization-round-trip`.

`HtmxViewMixin.dispatch` hijacked every request bearing the `HX-Request` header and 404'd when no signed `hx` token was present — breaking hx-boost navigation and hand-written hx-get/hx-post widgets on any mixin view. The handoff is now gated on the `hx` token being present; tokenless requests fall through to the page view's own dispatch. A present-but-invalid token still 404s. TDD'd; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)