### PR TITLE
refactor(#6): dispatch data flow — stop smuggling state through request.GET

### DIFF
--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -230,6 +230,11 @@ class BaseHxRequest:
 
     def _setup_hx_request(self, request, *args, **kwargs):
         self.request = request
+        # Mirror Django's View.setup: expose the resolved args/kwargs on the
+        # handler so hooks can read self.kwargs directly. Hooks still receive
+        # **kwargs too, so this is purely additive.
+        self.args = args
+        self.kwargs = kwargs
         self._view_get_args = args
         self._view_get_kwargs = kwargs
         self.renderer = Renderer()

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -207,7 +207,8 @@ class BaseHxRequest:
         queryset raises ``Http404`` (object-level authorization), not a 500.
         Non-model values are deserialized as plain JSON.
         """
-        serialized = request.GET.get("object")
+        payload = getattr(request, "hx_payload", None) or {}
+        serialized = payload.get("object")
         if not serialized:
             return None
 

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -4,6 +4,7 @@ import logging
 from urllib.parse import parse_qs, urlparse
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404, HttpRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -51,7 +52,15 @@ class HtmxViewMixin:
             and request.method.lower() in self.http_method_names
         ):
             request = self._resolve_hx_token(request)
-            kwargs.update(self.get_hx_extra_kwargs(request))
+            extra_kwargs = self.get_hx_extra_kwargs(request)
+            collisions = set(kwargs) & set(extra_kwargs)
+            if collisions:
+                raise ImproperlyConfigured(
+                    f"hx-requests kwarg(s) {sorted(collisions)} collide with URLconf "
+                    f"kwargs on view {self.__class__.__name__}. A signed template-tag "
+                    "kwarg must not shadow a URL kwarg -- rename the template-tag kwarg."
+                )
+            kwargs.update(extra_kwargs)
             hx_request = self._setup_hx_request(request, *args, **kwargs)
 
             # Use request from hx_request, in case use_current_url is set to True

--- a/hx_requests/views.py
+++ b/hx_requests/views.py
@@ -63,7 +63,8 @@ class HtmxViewMixin:
         return super().dispatch(request, *args, **kwargs)
 
     def get_hx_request(self, request):
-        hx_request_name = request.GET.get("hx_request_name")
+        payload = getattr(request, "hx_payload", None) or {}
+        hx_request_name = payload.get("name")
         if not hx_request_name:
             logger.debug(
                 "hx_requests: denied (404) on %s -- verified token carried no HxRequest name.",
@@ -92,12 +93,13 @@ class HtmxViewMixin:
 
     def _resolve_hx_token(self, request):
         """
-        Verify the signed ``hx`` token and rebuild ``request.GET`` so the rest
-        of the chain reads *trusted* framework data. Everything the framework
-        controls (name, object, kwargs) comes from the signed token; any
-        client-supplied framework params on the raw query string are dropped so
-        they cannot shadow or forge the verified values. Non-framework params
-        (page filters, runtime hx-vals) are left untouched.
+        Verify the signed ``hx`` token and attach its *trusted* contents to the
+        request as ``request.hx_payload`` (``{"name", "object", "kwargs", ...}``).
+        Everything the framework controls (name, object, kwargs) comes from the
+        signed token; any client-supplied framework params on the raw query
+        string are stripped so they cannot shadow or forge the verified values
+        and cannot leak into a page-view template's ``request.GET.urlencode()``.
+        Non-framework params (page filters, runtime hx-vals) are left untouched.
         """
         if not request.GET.get(HX_TOKEN_PARAM):
             logger.debug("hx_requests: denied (404) -- request carried no '%s' token.", HX_TOKEN_PARAM)
@@ -123,11 +125,11 @@ class HtmxViewMixin:
         for key in list(sanitized.keys()):
             if key in (HX_TOKEN_PARAM, "hx_request_name", "object"):
                 del sanitized[key]
-        sanitized["hx_request_name"] = payload["name"]
-        if payload.get("object"):
-            sanitized["object"] = payload["object"]
-
         request.GET = sanitized
+
+        # The verified payload is attached to the request, not smuggled back
+        # through request.GET; get_hx_request / get_hx_object read it here.
+        request.hx_payload = payload
         # Verified, serialized kwargs from the token -- the only source of
         # kwargs-as-context. Raw query params never feed this again.
         request._hx_kwargs = payload.get("kwargs", {})

--- a/tests/test_attributes_unit.py
+++ b/tests/test_attributes_unit.py
@@ -75,3 +75,17 @@ def test_hx_object_to_str(db):
     assert hx.hx_object_to_str() == ""
     hx.hx_object = Widget(name="x")
     assert hx.hx_object_to_str() == "Widget"
+
+
+def test_setup_exposes_args_and_kwargs_like_django_view_setup():
+    # Mirror Django's View.setup: the resolved positional/keyword args are
+    # available on the handler as self.args / self.kwargs after setup, so a
+    # hook can read them without every hook re-threading **kwargs.
+    class _ViewStub:
+        template_name = "simple.html"
+
+    hx = BaseHxRequest()
+    hx.view = _ViewStub()
+    hx._setup_hx_request(RequestFactory().get("/"), "posarg", flavor="spicy")
+    assert hx.args == ("posarg",)
+    assert hx.kwargs == {"flavor": "spicy"}

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -409,6 +409,15 @@ def test_tampered_hx_token_raises_404():
         BaseView.as_view()(request)
 
 
+def test_hx_kwarg_colliding_with_urlconf_kwarg_is_rejected():
+    # A template-tag kwarg must not silently shadow a URLconf kwarg (e.g. a
+    # URL <pk> the page view relies on). The collision is a misconfiguration.
+    from django.core.exceptions import ImproperlyConfigured
+
+    with pytest.raises(ImproperlyConfigured, match="pk"):
+        hx_get(hx.SimpleGetHx, BaseView, view_kwargs={"pk": 1}, hx_kwargs={"pk": 2})
+
+
 def test_unknown_hx_request_name_raises_404():
     request = RequestFactory().get("/", data={HX_TOKEN_PARAM: sign_hx_payload("does_not_exist")})
     request.META["HTTP_HX_REQUEST"] = True

--- a/tests/test_path_binding.py
+++ b/tests/test_path_binding.py
@@ -64,7 +64,7 @@ def test_bound_token_on_its_own_path_is_accepted():
     # The legitimate case: the token is used on the path it was bound to.
     request = _bound_request(path="/page/", bound_to="/page/")
     BaseView()._resolve_hx_token(request)
-    assert request.GET["hx_request_name"] == "simple_get"
+    assert request.hx_payload["name"] == "simple_get"
 
 
 @override_settings(HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
@@ -80,4 +80,4 @@ def test_global_setting_disables_enforcement():
     # immediately (e.g. after enabling it to work around path rewriting).
     request = _bound_request(path="/other/", bound_to="/page/")
     BaseView()._resolve_hx_token(request)
-    assert request.GET["hx_request_name"] == "simple_get"
+    assert request.hx_payload["name"] == "simple_get"

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -71,8 +71,27 @@ def test_resolve_strips_client_supplied_framework_params():
     BaseView()._resolve_hx_token(request)
 
     assert request.GET.get("object") is None  # loose object dropped, token had none
-    assert request.GET["hx_request_name"] == "simple_get"  # from token, not "other"
+    assert request.hx_payload["name"] == "simple_get"  # from token, not "other"
     assert request.GET["page"] == "2"  # legit loose param preserved
     # A loose param a client invents (whatever its name) is harmless: kwargs are
     # sourced only from the signed token, never from raw query input.
     assert request._hx_kwargs == {}  # kwargs sourced only from the token
+
+
+def test_resolve_does_not_smuggle_framework_data_through_get(widget):
+    # The verified name/object ride on request.hx_payload, never written back
+    # into request.GET. Otherwise a page-view template's
+    # `{{ request.GET.urlencode }}` (e.g. a pagination link) would carry
+    # hx_request_name/object into every link on the page.
+    token = sign_hx_payload("edit_widget", widget, flavor="spicy")
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: token, "page": "2"})
+    add_middleware_to_request(request)
+
+    BaseView()._resolve_hx_token(request)
+
+    assert request.hx_payload["name"] == "edit_widget"
+    assert request.hx_payload["object"]  # serialized ref present in the payload
+    assert "hx_request_name" not in request.GET
+    assert "object" not in request.GET
+    assert HX_TOKEN_PARAM not in request.GET
+    assert request.GET.urlencode() == "page=2"  # only the loose param survives


### PR DESCRIPTION
Audit round 2, item **#6**. Stacked PR **3 of 6**, base `audit2/mixin-hx-boost`. One commit per point:

- Attach the verified payload to `request.hx_payload` instead of writing name/object back into `request.GET` (framework params no longer leak into page-view `request.GET.urlencode()`).
- Expose `self.args`/`self.kwargs` at setup (Django `View.setup` style; `**kwargs` kept — non-breaking).
- Reject a signed hx kwarg that collides with a URLconf kwarg (`ImproperlyConfigured`) instead of silently shadowing a URL `pk`.
- Unify the two view-context harvest paths: POST refresh re-invokes the same `view.get()` path.

TDD'd; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)