### PR TITLE
feat(#7): hooks & extension points

### DIFF
--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -7,7 +7,7 @@ from functools import partial
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages import get_messages
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.forms import Form
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseNotAllowed
 from django.template import RequestContext
@@ -244,8 +244,6 @@ class BaseHxRequest:
         self._view_get_args = args
         self._view_get_kwargs = kwargs
         self.renderer = Renderer()
-        self.GET_template = self.GET_template or self.view.template_name
-        self.POST_template = self.POST_template or self.view.template_name
 
         if not hasattr(self, "hx_object"):
             self.hx_object = self.get_hx_object(request, **kwargs)
@@ -285,9 +283,39 @@ class BaseHxRequest:
         The template(s) to render for the current request method.
 
         Defaults to :attr:`POST_template` on POST and :attr:`GET_template` on
-        GET. Override to select templates dynamically.
+        GET. When neither is set, falls back to the host view's template,
+        resolved lazily -- ``template_name`` first, then
+        ``get_template_names()`` (implicit-naming ``DetailView``/``ListView``).
+        Raises :class:`~django.core.exceptions.ImproperlyConfigured` naming the
+        handler when nothing resolves, instead of an eager ``AttributeError``
+        at setup or a cryptic ``ValueError`` at render. Override to select
+        templates dynamically.
         """
-        return self.POST_template if self.is_post_request else self.GET_template
+        templates = self.POST_template if self.is_post_request else self.GET_template
+        if templates:
+            return templates
+        return self._view_template_fallback()
+
+    def _view_template_fallback(self):
+        view_template = getattr(self.view, "template_name", None)
+        if not view_template:
+            get_template_names = getattr(self.view, "get_template_names", None)
+            if callable(get_template_names):
+                # get_template_names() raises ImproperlyConfigured when it has
+                # nothing to offer (e.g. TemplateView with template_name=None);
+                # treat that as "no template" and fall through to our error.
+                with contextlib.suppress(ImproperlyConfigured):
+                    names = get_template_names()
+                    if names:
+                        view_template = list(names)
+        if not view_template:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} sets no GET_template/POST_template and its host "
+                f"view {type(self.view).__name__} provides no template (no template_name "
+                "and no resolvable get_template_names()). Set GET_template/POST_template on "
+                "the handler or template_name on the view."
+            )
+        return view_template
 
     def get_headers(self, **kwargs) -> dict:
         """
@@ -623,7 +651,10 @@ class FormHxRequest(BaseHxRequest):
         now contains the validation errors.)
         """
         if self.is_post_request and self.form.is_valid() is False:
-            return self._render_templates(self.GET_template, self.GET_block, **kwargs)
+            # Render the GET template (now carrying the errors), falling back to
+            # the host view's template the same way get_templates() does.
+            templates = self.GET_template or self._view_template_fallback()
+            return self._render_templates(templates, self.GET_block, **kwargs)
         return super().get_response_html(**kwargs)
 
     def get_form_kwargs(self, **kwargs):

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -269,6 +269,26 @@ class BaseHxRequest:
         verbose_name = str(self.hx_object._meta.verbose_name)
         return verbose_name[:1].upper() + verbose_name[1:]
 
+    def get_redirect_url(self, **kwargs) -> str | None:
+        """
+        URL to redirect to after a POST (emitted as the ``HX-Redirect``
+        header), or ``None`` for no redirect.
+
+        Defaults to the static :attr:`redirect` attribute. Override to compute
+        a redirect target dynamically instead of mutating ``self.redirect`` in
+        ``form_valid``.
+        """
+        return self.redirect
+
+    def get_templates(self):
+        """
+        The template(s) to render for the current request method.
+
+        Defaults to :attr:`POST_template` on POST and :attr:`GET_template` on
+        GET. Override to select templates dynamically.
+        """
+        return self.POST_template if self.is_post_request else self.GET_template
+
     def get_headers(self, **kwargs) -> dict:
         """
         Prepare the headers for the response.
@@ -277,8 +297,10 @@ class BaseHxRequest:
         if self.is_post_request:
             if self.refresh_page:
                 headers["HX-Refresh"] = "true"
-            elif self.redirect:
-                headers["HX-Redirect"] = self.redirect
+            else:
+                redirect_url = self.get_redirect_url(**kwargs)
+                if redirect_url:
+                    headers["HX-Redirect"] = redirect_url
         if self.no_swap:
             headers["HX-Reswap"] = "none"
 
@@ -371,13 +393,13 @@ class BaseHxRequest:
         Prepare the HTML for the response.
         """
         if self.is_post_request:
-            if self.refresh_page or self.redirect or self.return_empty:
+            if self.refresh_page or self.get_redirect_url(**kwargs) or self.return_empty:
                 html = ""
             else:
-                html = self._render_templates(self.POST_template, self.POST_block, **kwargs)
+                html = self._render_templates(self.get_templates(), self.POST_block, **kwargs)
 
         else:
-            html = self._render_templates(self.GET_template, self.GET_block, **kwargs)
+            html = self._render_templates(self.get_templates(), self.GET_block, **kwargs)
 
         return html
 
@@ -446,7 +468,7 @@ class BaseHxRequest:
         Gets the response.
         """
         html = self.get_response_html(**kwargs)
-        if self.use_messages and not (self.refresh_page or self.redirect):
+        if self.use_messages and not (self.refresh_page or self.get_redirect_url(**kwargs)):
             html += self._get_messages_html(**kwargs)
 
         return HttpResponse(

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -169,11 +169,17 @@ class BaseHxRequest:
         if self.hx_object and self.hx_object.pk:
             with contextlib.suppress(ObjectDoesNotExist):
                 self.hx_object.refresh_from_db()
-        if self.refresh_views_context_on_POST:
-            if hasattr(self.view, "object") and self.view.object:
-                self.view.object.refresh_from_db()
-                context["object"] = self.view.object
-            context.update(self.view.get_context_data(**kwargs))
+        if self.refresh_views_context_on_POST and self.get_views_context:
+            # Re-harvest the page view's context through the same view.get()
+            # path used on GET, so POST refresh and GET go through identical
+            # machinery rather than a divergent get_context_data() call plus an
+            # ad-hoc view.object refresh. Invalidate the cached pre-post
+            # snapshot so the property recomputes against the mutated state;
+            # view.get() re-runs get_object()/get_queryset(), so the fresh
+            # object and querysets land in context automatically.
+            self.__dict__.pop("view_response", None)
+            if hasattr(self.view_response, "context_data"):
+                context.update(self.view_response.context_data)
         context[self.hx_object_name] = self.hx_object
 
         return context

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -590,10 +590,18 @@ class FormHxRequest(BaseHxRequest):
         (useful when the form already renders inline field errors).
     """
 
-    form_class: Form = None
+    form_class: type[Form] | None = None
     add_form_errors_to_error_message: bool = False
     set_initial_from_kwargs: bool = False
     show_form_invalid_message: bool = True
+
+    def _setup_hx_request(self, request, *args, **kwargs):
+        if self.form_class is None:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} is a FormHxRequest but sets no form_class. "
+                "Set form_class to the Form/ModelForm this handler drives."
+            )
+        super()._setup_hx_request(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs) -> dict:
         """

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -478,8 +478,34 @@ class BaseHxRequest:
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Method that all POST requests hit.
+
+        Runs :meth:`post_action` and builds the standard response from
+        ``_get_response`` unless the hook returns its own ``HttpResponse``.
         """
-        return self._get_response(**kwargs)
+        response = self.post_action(**kwargs)
+        return response if response is not None else self._get_response(**kwargs)
+
+    def post_action(self, **kwargs) -> HttpResponse | None:
+        """
+        Hook for a non-form POST side effect (toggle / increment / enqueue).
+
+        Override to perform the action. Return ``None`` (default) to let
+        ``post`` build the standard response, or return an ``HttpResponse`` to
+        short-circuit with custom output. Saves the copy-paste ``post``
+        override the common non-form POST used to require.
+
+        Example::
+
+            class ToggleWidgetHx(BaseHxRequest):
+                name = "toggle_widget"
+                POST_template = "widget_row.html"
+
+                def post_action(self, **kwargs):
+                    # Run the side effect; return None so post() renders
+                    # POST_template with the refreshed context as usual.
+                    self.hx_object.toggle()
+        """
+        return None
 
 
 class FormHxRequest(BaseHxRequest):

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -363,6 +363,22 @@ class PostActionSideEffectHx(BaseHxRequest):
         return None
 
 
+class DynamicRedirectHx(BaseHxRequest):
+    name = "dynamic_redirect"
+    GET_template = "simple.html"
+
+    def get_redirect_url(self, **kwargs):
+        return "/computed-target/"
+
+
+class DynamicTemplateHx(BaseHxRequest):
+    name = "dynamic_template"
+    GET_template = "simple.html"
+
+    def get_templates(self):
+        return "second.html"
+
+
 # --------------------------------------------------------------------------
 # Registry edge case: a class with a `name` that is NOT an HxRequest
 # --------------------------------------------------------------------------

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -341,6 +341,29 @@ class ExtraTriggersFormModalHx(WidgetFormModalHx):
 
 
 # --------------------------------------------------------------------------
+# Extension point: post_action hook
+# --------------------------------------------------------------------------
+
+
+class PostActionShortCircuitHx(BaseHxRequest):
+    name = "post_action_short_circuit"
+    GET_template = "simple.html"
+
+    def post_action(self, **kwargs):
+        return HttpResponse("action-response")
+
+
+class PostActionSideEffectHx(BaseHxRequest):
+    name = "post_action_side_effect"
+    GET_template = "simple.html"
+    POST_template = "post.html"
+
+    def post_action(self, **kwargs):
+        Widget.objects.create(name="from-post-action")
+        return None
+
+
+# --------------------------------------------------------------------------
 # Registry edge case: a class with a `name` that is NOT an HxRequest
 # --------------------------------------------------------------------------
 

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -262,6 +262,12 @@ class WidgetFormHx(FormHxRequest):
     POST_template = "form_success.html"
 
 
+class NoFormClassHx(FormHxRequest):
+    # form_class intentionally left as None -- must fail loudly at setup.
+    name = "no_form_class"
+    GET_template = "form.html"
+
+
 class InitialKwargsFormHx(WidgetFormHx):
     name = "initial_kwargs_form"
     set_initial_from_kwargs = True

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -40,6 +40,13 @@ class ViewTemplateFallbackHx(BaseHxRequest):
     name = "view_template_fallback"
 
 
+class ViewTemplateNamesFallbackHx(BaseHxRequest):
+    # No GET_template and no view context harvest: isolates template
+    # resolution via the host view's get_template_names().
+    name = "view_template_names_fallback"
+    get_views_context = False
+
+
 class PostTemplateHx(BaseHxRequest):
     name = "post_template"
     GET_template = "simple.html"

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -1,8 +1,22 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views import View
 from django.views.generic import ListView, TemplateView, UpdateView
 from test_app.models import Widget
 
 from hx_requests.views import HtmxViewMixin
+
+
+class PlainViewHost(HtmxViewMixin, View):
+    """A plain View with no template_name -- the eager fallback used to
+    AttributeError on it; it should raise ImproperlyConfigured instead."""
+
+
+class GetTemplateNamesHost(HtmxViewMixin, View):
+    """A View that resolves its template only via get_template_names() (as an
+    implicit-naming DetailView/ListView does), not a template_name attribute."""
+
+    def get_template_names(self):
+        return ["second.html"]
 
 
 class BaseView(HtmxViewMixin, TemplateView):

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -347,6 +347,22 @@ def test_messages_disabled_globally():
 
 
 # --------------------------------------------------------------------------
+# Extension point: post_action hook
+# --------------------------------------------------------------------------
+
+
+def test_post_action_short_circuits_with_its_response():
+    response = hx_post(hx.PostActionShortCircuitHx, BaseView)
+    assert content_of(response) == "action-response"
+
+
+def test_post_action_returning_none_runs_side_effect_and_renders_normally():
+    response = hx_post(hx.PostActionSideEffectHx, BaseView)
+    assert Widget.objects.filter(name="from-post-action").exists()
+    assert response.status_code == 200
+
+
+# --------------------------------------------------------------------------
 # Dispatch / routing
 # --------------------------------------------------------------------------
 

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -46,6 +46,26 @@ def test_post_template_falls_back_to_view_template():
     assert "base-view-template" in content_of(response)
 
 
+def test_template_falls_back_to_view_get_template_names():
+    # A host view that only resolves its template via get_template_names()
+    # (implicit-naming DetailView/ListView) is honored lazily.
+    from test_app.views import GetTemplateNamesHost
+
+    response = hx_get(hx.ViewTemplateNamesFallbackHx, GetTemplateNamesHost)
+    assert "second-template" in content_of(response)
+
+
+def test_missing_template_on_plain_view_host_raises_improperly_configured():
+    # A plain View host has no template_name and no get_template_names; when
+    # the handler also sets no template, fail with a clear ImproperlyConfigured
+    # naming the handler instead of a cryptic AttributeError.
+    from django.core.exceptions import ImproperlyConfigured
+    from test_app.views import PlainViewHost
+
+    with pytest.raises(ImproperlyConfigured, match="ViewTemplateFallbackHx"):
+        hx_get(hx.ViewTemplateFallbackHx, PlainViewHost)
+
+
 def test_multiple_get_templates_all_rendered():
     response = hx_get(hx.MultiTemplateHx, BaseView)
     html = content_of(response)

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -362,6 +362,20 @@ def test_post_action_returning_none_runs_side_effect_and_renders_normally():
     assert response.status_code == 200
 
 
+def test_get_redirect_url_hook_drives_the_redirect_response():
+    # A dynamic redirect can be computed via get_redirect_url instead of
+    # mutating self.redirect. The HX-Redirect header uses the computed URL and
+    # the body is empty (a redirect renders nothing).
+    response = hx_post(hx.DynamicRedirectHx, BaseView)
+    assert response.headers["HX-Redirect"] == "/computed-target/"
+    assert content_of(response) == ""
+
+
+def test_get_templates_hook_selects_the_rendered_template():
+    response = hx_get(hx.DynamicTemplateHx, BaseView)
+    assert "second-template" in content_of(response)
+
+
 # --------------------------------------------------------------------------
 # Dispatch / routing
 # --------------------------------------------------------------------------

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -396,6 +396,13 @@ def test_get_templates_hook_selects_the_rendered_template():
     assert "second-template" in content_of(response)
 
 
+def test_form_hx_request_without_form_class_raises_improperly_configured():
+    from django.core.exceptions import ImproperlyConfigured
+
+    with pytest.raises(ImproperlyConfigured, match="NoFormClassHx"):
+        hx_get(hx.NoFormClassHx, BaseView)
+
+
 # --------------------------------------------------------------------------
 # Dispatch / routing
 # --------------------------------------------------------------------------

--- a/tests/test_lazy_context.py
+++ b/tests/test_lazy_context.py
@@ -38,3 +38,14 @@ def test_view_get_runs_once_when_context_is_rendered():
     CountingView.get_call_count = 0
     hx_get(hx.SimpleGetHx, CountingView)
     assert CountingView.get_call_count == 1
+
+
+@pytest.mark.django_db()
+def test_refresh_context_on_post_reharvests_through_view_get():
+    # refresh_views_context_on_POST rebuilds the view context by re-invoking
+    # the same view.get() harvest path (not a divergent get_context_data call),
+    # so the post-mutation snapshot goes through identical machinery. That is
+    # the pre-post snapshot plus one fresh re-harvest = two view.get() calls.
+    CountingView.get_call_count = 0
+    hx_post(hx.AddWidgetRefreshContextHx, CountingView)
+    assert CountingView.get_call_count == 2


### PR DESCRIPTION
Audit round 2, item **#7**. Now rebased onto `master` (its underlying PRs #204–#206 have merged). One commit per point:

- `refresh POST context through the same view.get() harvest` — POST refresh re-runs the same `view.get()` path as GET (was #206's point 4, which dropped out of that merge), so list/queryset context is re-evaluated after a mutation instead of served stale.
- `post_action` hook for non-form POSTs (toggle / increment / enqueue) — no more copy-paste `post()` override. Default returns `None`; handlers that already override `post()` are unaffected.
- `get_redirect_url` / `get_templates` computed hooks — dynamic redirect/templates without mutating `self.redirect` in `form_valid`.
- Lazy view-template fallback via `get_template_names()`, raising `ImproperlyConfigured` naming the handler instead of an eager `AttributeError` at setup or a cryptic `ValueError` at render.
- `FormHxRequest` with `form_class=None` raises `ImproperlyConfigured` at setup; annotation fixed to `type[Form] | None`.

The `renderer_class` / `response_class` extension points were dropped — thin value, no current consumer, and `response_class` only accepts `HttpResponse` subclasses sharing the `(content, headers=)` constructor (not `TemplateResponse`).

TDD'd; suite green (263 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
