### PR TITLE
test(#12): test-suite improvements

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,6 +24,31 @@ def add_middleware_to_request(request):
     return request
 
 
+def content_of(response):
+    """Decode a response body to text."""
+    return response.content.decode()
+
+
+def make_context(path="/page/", **extra):
+    """A minimal template-tag context wrapping a GET request."""
+    return {"request": RequestFactory().get(path, **extra)}
+
+
+def make_hx(method="get", **attrs):
+    """
+    Instantiate a bare BaseHxRequest with a request and the given attributes,
+    for unit tests that exercise a single method in isolation. (Handlers that
+    need a wired get_triggers or a concrete form subclass build their own.)
+    """
+    from hx_requests.hx_requests import BaseHxRequest
+
+    hx = BaseHxRequest()
+    hx.request = getattr(RequestFactory(), method)("/")
+    for key, value in attrs.items():
+        setattr(hx, key, value)
+    return hx
+
+
 def _create_test_request(
     hx_request,
     request_attrs=None,

--- a/tests/test_attributes_unit.py
+++ b/tests/test_attributes_unit.py
@@ -89,3 +89,17 @@ def test_setup_exposes_args_and_kwargs_like_django_view_setup():
     hx._setup_hx_request(RequestFactory().get("/"), "posarg", flavor="spicy")
     assert hx.args == ("posarg",)
     assert hx.kwargs == {"flavor": "spicy"}
+
+
+def test_preset_hx_object_is_not_overwritten_at_setup():
+    # A pre-set hx_object (assigned before setup) is left untouched -- setup
+    # only resolves it from the token when it has not already been provided.
+    class _ViewStub:
+        template_name = "simple.html"
+
+    hx = BaseHxRequest()
+    hx.view = _ViewStub()
+    sentinel = object()
+    hx.hx_object = sentinel
+    hx._setup_hx_request(RequestFactory().get("/"))
+    assert hx.hx_object is sentinel

--- a/tests/test_attributes_unit.py
+++ b/tests/test_attributes_unit.py
@@ -9,6 +9,7 @@ from hx_requests.hx_requests import (
     FormModalHxRequest,
     ModalHxRequest,
 )
+from tests.helpers import make_hx
 
 
 def test_base_hx_request_defaults():
@@ -46,14 +47,6 @@ def test_form_modal_defaults_and_inheritance():
     assert issubclass(FormModalHxRequest, ModalHxRequest)
     assert issubclass(FormModalHxRequest, FormHxRequest)
     assert issubclass(DeleteHxRequest, BaseHxRequest)
-
-
-def make_hx(**attrs):
-    hx = BaseHxRequest()
-    hx.request = RequestFactory().get("/")
-    for key, value in attrs.items():
-        setattr(hx, key, value)
-    return hx
 
 
 @override_settings(HX_REQUESTS_USE_HX_MESSAGES=True)

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -11,13 +11,9 @@ from test_app.models import Widget
 from test_app.views import BaseView, WidgetContextView, WidgetListView, WidgetUpdateView
 
 from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
-from tests.helpers import add_middleware_to_request, hx_get, hx_post
+from tests.helpers import add_middleware_to_request, content_of, hx_get, hx_post
 
 pytestmark = pytest.mark.django_db
-
-
-def content_of(response):
-    return response.content.decode()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -322,6 +322,36 @@ def test_use_current_url_without_header_is_a_noop():
     assert "bar:from-request" in html
 
 
+def test_use_current_url_skips_framework_params_from_the_header():
+    # Framework params tacked onto HX-Current-URL (a forged object=, a fake
+    # token) must never be merged from the current URL -- those are trusted
+    # only via the signed token. Only ordinary params come through. (kwargs
+    # are carried inside the signed token, never as query params, so there is
+    # no kwarg param to forge here.)
+    from test_app.views import BaseView as _BaseView
+
+    request = RequestFactory().get("/page/")
+    request.META["HTTP_HX_CURRENT_URL"] = (
+        "http://testserver/page?foo=ok&object=forged&hx_request_name=evil&"
+        f"{HX_TOKEN_PARAM}=forgedtoken"
+    )
+    result = _BaseView()._use_current_url(request)
+
+    assert result.GET["foo"] == "ok"
+    assert "object" not in result.GET
+    assert "hx_request_name" not in result.GET
+    assert HX_TOKEN_PARAM not in result.GET
+
+
+def test_empty_name_signed_token_is_rejected():
+    # A validly-signed token whose name is empty is not a real handler -> 404.
+    request = RequestFactory().get("/", data={HX_TOKEN_PARAM: sign_hx_payload("")})
+    request.META["HTTP_HX_REQUEST"] = True
+    add_middleware_to_request(request)
+    with pytest.raises(Http404, match="hx_request_name"):
+        BaseView.as_view()(request)
+
+
 # --------------------------------------------------------------------------
 # Triggers
 # --------------------------------------------------------------------------

--- a/tests/test_form_hx_request.py
+++ b/tests/test_form_hx_request.py
@@ -5,13 +5,9 @@ from test_app import hx_requests as hx
 from test_app.models import Widget
 from test_app.views import BaseView
 
-from tests.helpers import hx_get, hx_post
+from tests.helpers import content_of, hx_get, hx_post
 
 pytestmark = pytest.mark.django_db
-
-
-def content_of(response):
-    return response.content.decode()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_headers_unit.py
+++ b/tests/test_headers_unit.py
@@ -1,16 +1,6 @@
 """Unit tests for BaseHxRequest.get_headers precedence and method handling."""
 
-from django.test import RequestFactory
-
-from hx_requests.hx_requests import BaseHxRequest
-
-
-def make_hx(method="get", **attrs):
-    hx = BaseHxRequest()
-    hx.request = getattr(RequestFactory(), method)("/")
-    for key, value in attrs.items():
-        setattr(hx, key, value)
-    return hx
+from tests.helpers import make_hx
 
 
 def test_no_flags_no_headers():

--- a/tests/test_hx_tags.py
+++ b/tests/test_hx_tags.py
@@ -7,14 +7,10 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.template import Context, Template
-from django.test import RequestFactory
 
 from hx_requests.templatetags.hx_tags import hx_get, hx_post, hx_url
 from hx_requests.utils import HX_TOKEN_PARAM, deserialize, deserialize_kwargs, unsign_hx_payload
-
-
-def make_context(path="/page/", **extra):
-    return {"request": RequestFactory().get(path, **extra)}
+from tests.helpers import make_context
 
 
 def attr_value(attr, name):

--- a/tests/test_hx_tags.py
+++ b/tests/test_hx_tags.py
@@ -56,9 +56,10 @@ def test_hx_post_renders_quoted_attribute_and_csrf_headers():
     # double quotes are HTML-escaped inside the attribute value.
     headers = json.loads(attr_value(out, "hx-headers"))
     token = headers["X-CSRFTOKEN"]
+    # A non-empty CSRF token string is emitted. The exact length/format is
+    # Django's business (a masked token today) -- don't couple the test to it.
     assert isinstance(token, str)
-    # get_token returns a masked 64-char token regardless of CSRF config.
-    assert len(token) == 64
+    assert token
 
 
 def test_hx_post_always_includes_csrf_headers():

--- a/tests/test_lazy_context.py
+++ b/tests/test_lazy_context.py
@@ -7,35 +7,40 @@ page view's query cost.
 """
 
 import pytest
-from helpers import hx_get, hx_post
 from test_app import hx_requests as hx
 from test_app.views import CountingView
+
+from tests.helpers import hx_get, hx_post
+
+
+@pytest.fixture(autouse=True)
+def _reset_counting_view():
+    # CountingView.get_call_count is shared class state; reset it before every
+    # test so counts can't leak between them.
+    CountingView.get_call_count = 0
+    return
 
 
 @pytest.mark.django_db()
 def test_view_get_skipped_when_post_renders_nothing():
-    CountingView.get_call_count = 0
     hx_post(hx.RefreshHx, CountingView)
     assert CountingView.get_call_count == 0
 
 
 @pytest.mark.django_db()
 def test_view_get_skipped_on_redirect_post():
-    CountingView.get_call_count = 0
     hx_post(hx.RedirectHx, CountingView)
     assert CountingView.get_call_count == 0
 
 
 @pytest.mark.django_db()
 def test_view_get_skipped_on_return_empty_post():
-    CountingView.get_call_count = 0
     hx_post(hx.ReturnEmptyHx, CountingView)
     assert CountingView.get_call_count == 0
 
 
 @pytest.mark.django_db()
 def test_view_get_runs_once_when_context_is_rendered():
-    CountingView.get_call_count = 0
     hx_get(hx.SimpleGetHx, CountingView)
     assert CountingView.get_call_count == 1
 
@@ -46,6 +51,5 @@ def test_refresh_context_on_post_reharvests_through_view_get():
     # the same view.get() harvest path (not a divergent get_context_data call),
     # so the post-mutation snapshot goes through identical machinery. That is
     # the pre-post snapshot plus one fresh re-harvest = two view.get() calls.
-    CountingView.get_call_count = 0
     hx_post(hx.AddWidgetRefreshContextHx, CountingView)
     assert CountingView.get_call_count == 2

--- a/tests/test_modal.py
+++ b/tests/test_modal.py
@@ -6,13 +6,9 @@ from test_app import hx_requests as hx
 from test_app.models import Widget
 from test_app.views import BaseView
 
-from tests.helpers import hx_get, hx_post
+from tests.helpers import content_of, hx_get, hx_post
 
 pytestmark = pytest.mark.django_db
-
-
-def content_of(response):
-    return response.content.decode()
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_path_binding.py
+++ b/tests/test_path_binding.py
@@ -67,6 +67,21 @@ def test_bound_token_on_its_own_path_is_accepted():
     assert request.hx_payload["name"] == "simple_get"
 
 
+def test_replaying_bound_token_to_another_path_is_rejected_end_to_end():
+    # The same rejection, but exercised through the full view dispatch instead
+    # of the private _resolve_hx_token, so the enforcement is covered on the
+    # real request path a client would hit.
+    request = _bound_request(path="/other/", bound_to="/page/")
+    with pytest.raises(Http404, match="bound to a different path"):
+        BaseView.as_view()(request)
+
+
+def test_bound_token_on_its_own_path_dispatches_end_to_end():
+    request = _bound_request(path="/page/", bound_to="/page/")
+    response = BaseView.as_view()(request)
+    assert response.status_code == 200
+
+
 @override_settings(HX_REQUESTS_BIND_TOKEN_TO_PATH=False)
 def test_global_setting_disables_binding_at_mint():
     # The global kill switch stops new tokens from being path-bound at all.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -114,6 +114,16 @@ def test_parse_file_skips_unparsable_files_with_warning(clean_registry, tmp_path
     assert "scratch.py" in caplog.text
 
 
+def test_parse_file_skips_unreadable_file_with_warning(clean_registry, caplog):
+    # A file that cannot be read (missing / unreadable) is skipped loudly
+    # rather than blowing up discovery for the whole app.
+    HxRequestRegistry.reset()
+    with caplog.at_level(logging.WARNING, logger="hx_requests.hx_registry"):
+        HxRequestRegistry._parse_file("/no/such/hx_requests_file.py", "scratch.missing")
+    assert HxRequestRegistry._registry == {}
+    assert "could not read it" in caplog.text
+
+
 def test_duplicate_names_raise(clean_registry, tmp_path):
     HxRequestRegistry.reset()
     source = tmp_path / "scratch.py"

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -15,13 +15,9 @@ from test_app import hx_requests as hx
 from test_app.views import BaseView
 
 from hx_requests.utils import HX_TOKEN_PARAM, sign_hx_payload
-from tests.helpers import add_middleware_to_request, hx_get
+from tests.helpers import add_middleware_to_request, content_of, hx_get
 
 pytestmark = pytest.mark.django_db
-
-
-def content_of(response):
-    return response.content.decode()
 
 
 def test_loose_kwarg_param_is_not_injected_into_context():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,7 @@ from hx_requests.utils import (
     sign_hx_payload,
     unsign_hx_payload,
 )
+from tests.helpers import make_context
 
 # --------------------------------------------------------------------------
 # serialize / deserialize
@@ -275,10 +276,6 @@ def test_is_hx_request_false_on_bad_signature():
 # --------------------------------------------------------------------------
 # get_url
 # --------------------------------------------------------------------------
-
-
-def make_context(path="/page/", **extra):
-    return {"request": RequestFactory().get(path, **extra)}
 
 
 def token_from_url(url):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -203,14 +203,25 @@ def test_tampered_token_fails_verification():
 def test_handler_name_is_bound_to_the_signature():
     # The name lives inside the signed payload, so it cannot be swapped for
     # another handler without invalidating the token (this is why a per-name
-    # salt is unnecessary).
+    # salt is unnecessary). The token is base64, so a naive str.replace never
+    # touches the name -- decode the payload, swap the name, re-encode with the
+    # original signature, and assert loads() rejects it.
+    import json
+
     from django.core import signing
 
     token = sign_hx_payload("view_user")
-    forged = token.replace("view_user", "delete_user")
-    if forged != token:
-        with pytest.raises(signing.BadSignature):
-            unsign_hx_payload(forged)
+    payload_b64, signed_rest = token.split(":", 1)  # "<payload>:<timestamp>:<sig>"
+    payload = json.loads(signing.b64_decode(payload_b64.encode()))
+    assert payload["name"] == "view_user"
+
+    payload["name"] = "delete_user"
+    forged_b64 = signing.b64_encode(json.dumps(payload).encode()).decode()
+    forged = f"{forged_b64}:{signed_rest}"
+
+    assert forged != token  # the swap really changed the token
+    with pytest.raises(signing.BadSignature):
+        unsign_hx_payload(forged)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Audit round 2, item **#12**. Stacked PR **5 of 6**, base `audit2/hooks-and-extension-points`.

- Make the name-binding token test actually assert (it was a no-op on a base64 token).
- Cover path-binding enforcement end-to-end through dispatch.
- Cover previously-untested paths: `_use_current_url` framework-param skip, empty-name token, registry OSError skip, pre-set `hx_object`.
- Stop coupling the CSRF header test to Django's token length.
- Consolidate duplicated `content_of`/`make_context`/`make_hx` into `tests/helpers.py`.
- Fix `test_lazy_context` import (`helpers`→`tests.helpers`) and reset shared `CountingView` state via autouse fixture.

Suite green (271 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)