### PR TITLE
feat: add get_no_swap and get_return_empty computed hooks

### DIFF
--- a/docs/how_tos/more_how_tos.rst
+++ b/docs/how_tos/more_how_tos.rst
@@ -9,17 +9,21 @@ When :code:`no_swap` is set, no HTML is swapped into the DOM. A common use case 
 If the form is valid, you may want to swap in updated content to reflect the changes.
 However, if the form is invalid, you may only want to display error messages without modifying the page structure.
 
-.. code-block:: python
+Set it statically with the :code:`no_swap` attribute, or compute it per request
+by overriding :code:`get_no_swap` — cleaner than flipping :code:`self.no_swap`
+inside :code:`form_valid` / :code:`form_invalid` just to change the swap:
 
-    from django.contrib import messages
+.. code-block:: python
 
     class MyHxRequest(FormHxRequest):
         ...
 
-        def form_invalid(self, **kwargs):
-            self.no_swap = True
-            messages.error(self.request, "Sorry there was an error")
-            return super().form_invalid(**kwargs)
+        def get_no_swap(self, **kwargs):
+            # Swap in updated content when the form saves; leave the page
+            # untouched (errors show via messages) when it doesn't.
+            return not self.form.is_valid()
+
+There is a matching :code:`get_return_empty` hook for computing :code:`return_empty` the same way.
 
 
 How Do I Add Form Errors To The Error Message?

--- a/hx_requests/hx_requests.py
+++ b/hx_requests/hx_requests.py
@@ -55,9 +55,11 @@ class BaseHxRequest:
     redirect : str, optional
         URL to redirect to after a POST request
     return_empty : bool
-        If True, returns an empty HTTPResponse after a POST request
+        If True, returns an empty HTTPResponse after a POST request.
+        For a per-request decision, override :meth:`get_return_empty` instead.
     no_swap : bool
-        If True, does not do a swap
+        If True, does not do a swap.
+        For a per-request decision, override :meth:`get_no_swap` instead.
     show_messages: bool
         If True and there is a message set and settings.HX_REQUESTS_USE_HX_MESSAGES is True
         then the set message is displayed
@@ -250,6 +252,11 @@ class BaseHxRequest:
 
         # POST must snapshot the view context before post() mutates it; skip that
         # work when the POST renders nothing (refresh_page/redirect/return_empty).
+        # This is a setup-time optimization only, so it reads the static
+        # attributes (like self.redirect above) rather than the get_*() hooks:
+        # the form has not been validated yet here, so a hook keyed on form state
+        # can't run. The hooks stay authoritative at render time; a hook-only
+        # handler simply snapshots context it may not use (harmless).
         if (
             self.get_views_context
             and self.is_post_request
@@ -277,6 +284,26 @@ class BaseHxRequest:
         ``form_valid``.
         """
         return self.redirect
+
+    def get_no_swap(self, **kwargs) -> bool:
+        """
+        Whether to suppress the DOM swap (emitted as ``HX-Reswap: none``).
+
+        Defaults to the static :attr:`no_swap` attribute. Override to decide
+        per request -- e.g. ``return not self.form.is_valid()`` -- instead of
+        mutating ``self.no_swap`` in ``form_valid``/``form_invalid``.
+        """
+        return self.no_swap
+
+    def get_return_empty(self, **kwargs) -> bool:
+        """
+        Whether the POST response body should be empty.
+
+        Defaults to the static :attr:`return_empty` attribute. Override to
+        decide per request instead of mutating ``self.return_empty`` in
+        ``form_valid``/``form_invalid``.
+        """
+        return self.return_empty
 
     def get_templates(self):
         """
@@ -329,7 +356,7 @@ class BaseHxRequest:
                 redirect_url = self.get_redirect_url(**kwargs)
                 if redirect_url:
                     headers["HX-Redirect"] = redirect_url
-        if self.no_swap:
+        if self.get_no_swap(**kwargs):
             headers["HX-Reswap"] = "none"
 
         headers.update(self.get_trigger_headers(**kwargs))
@@ -421,7 +448,7 @@ class BaseHxRequest:
         Prepare the HTML for the response.
         """
         if self.is_post_request:
-            if self.refresh_page or self.get_redirect_url(**kwargs) or self.return_empty:
+            if self.refresh_page or self.get_redirect_url(**kwargs) or self.get_return_empty(**kwargs):
                 html = ""
             else:
                 html = self._render_templates(self.get_templates(), self.POST_block, **kwargs)

--- a/tests/test_app/hx_requests.py
+++ b/tests/test_app/hx_requests.py
@@ -392,6 +392,24 @@ class DynamicTemplateHx(BaseHxRequest):
         return "second.html"
 
 
+class DynamicNoSwapHx(BaseHxRequest):
+    name = "dynamic_no_swap"
+    GET_template = "simple.html"
+
+    def get_no_swap(self, **kwargs):
+        # Computed per request instead of a static attribute.
+        return True
+
+
+class DynamicReturnEmptyHx(BaseHxRequest):
+    name = "dynamic_return_empty"
+    GET_template = "simple.html"
+
+    def get_return_empty(self, **kwargs):
+        # Computed per request instead of a static attribute.
+        return True
+
+
 # --------------------------------------------------------------------------
 # Registry edge case: a class with a `name` that is NOT an HxRequest
 # --------------------------------------------------------------------------

--- a/tests/test_base_hx_request.py
+++ b/tests/test_base_hx_request.py
@@ -422,6 +422,20 @@ def test_get_templates_hook_selects_the_rendered_template():
     assert "second-template" in content_of(response)
 
 
+def test_get_no_swap_hook_drives_the_reswap_header():
+    # no_swap can be computed via get_no_swap instead of mutating self.no_swap
+    # in form_valid/form_invalid.
+    response = hx_get(hx.DynamicNoSwapHx, BaseView)
+    assert response["HX-Reswap"] == "none"
+
+
+def test_get_return_empty_hook_yields_an_empty_body():
+    # return_empty can be computed via get_return_empty instead of a static
+    # attribute.
+    response = hx_post(hx.DynamicReturnEmptyHx, BaseView)
+    assert content_of(response) == ""
+
+
 def test_form_hx_request_without_form_class_raises_improperly_configured():
     from django.core.exceptions import ImproperlyConfigured
 

--- a/tests/test_headers_unit.py
+++ b/tests/test_headers_unit.py
@@ -39,3 +39,19 @@ def test_trigger_headers_are_merged_in():
 def test_is_post_request_property():
     assert make_hx("post").is_post_request is True
     assert make_hx("get").is_post_request is False
+
+
+def test_get_no_swap_defaults_to_the_attribute():
+    assert make_hx().get_no_swap() is False
+    assert make_hx(no_swap=True).get_no_swap() is True
+
+
+def test_get_return_empty_defaults_to_the_attribute():
+    assert make_hx().get_return_empty() is False
+    assert make_hx(return_empty=True).get_return_empty() is True
+
+
+def test_get_no_swap_hook_overrides_the_reswap_header():
+    hx = make_hx("post")
+    hx.get_no_swap = lambda **kwargs: True
+    assert hx.get_headers() == {"HX-Reswap": "none"}


### PR DESCRIPTION
## What

Adds two computed hooks on `BaseHxRequest`, mirroring the existing `get_redirect_url` / `get_templates` pattern:

- `get_no_swap(self, **kwargs) -> bool` — defaults to the `no_swap` attribute
- `get_return_empty(self, **kwargs) -> bool` — defaults to the `return_empty` attribute

## Why

`no_swap` and `return_empty` could only be set as static class attributes. To make them conditional (e.g. *"suppress the swap only when the form errored"*), users had to override `form_valid` / `form_invalid` **solely to mutate the flag** — noisy and easy to get wrong. With the hooks you write the intent directly:

```python
class MyHxRequest(FormHxRequest):
    def get_no_swap(self, **kwargs):
        return not self.form.is_valid()
```

## Details

- `get_headers` and `get_response_html` now read through the hooks.
- The setup-time view-context snapshot pre-check in `_setup_hx_request` intentionally keeps reading the **static** `return_empty` attribute: the form isn't validated yet at setup, so a hook keyed on form state can't run there. The hooks stay authoritative at render time; a hook-only handler just snapshots context it may not use (harmless). Documented inline.
- **Fully backward-compatible** — the attributes remain the defaults, and existing code (attribute or `form_valid`-mutation) keeps working.
- Updated the "What Is no_swap For?" how-to to demonstrate `get_no_swap` instead of flipping `self.no_swap` in `form_invalid`.

## Tests

New unit + integration tests: hook defaults return the attribute; overriding `get_no_swap` drives the `HX-Reswap: none` header; overriding `get_return_empty` yields an empty POST body. Full suite: **274 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)